### PR TITLE
Knife version should show knife version instead of Chef Infra Client version

### DIFF
--- a/lib/chef/application/knife.rb
+++ b/lib/chef/application/knife.rb
@@ -143,9 +143,9 @@ class Chef::Application::Knife < Chef::Application
   option :version,
     short: "-v",
     long: "--version",
-    description: "Show #{ChefUtils::Dist::Infra::PRODUCT} version.",
+    description: "Show knife version.",
     boolean: true,
-    proc: lambda { |v| puts "#{ChefUtils::Dist::Infra::PRODUCT}: #{Chef::Knife::VERSION}" },
+    proc: lambda { |v| puts "knife: #{Chef::Knife::VERSION}" },
     exit: 0
 
   option :fips,
@@ -225,7 +225,7 @@ class Chef::Application::Knife < Chef::Application
     end
 
     if want_help?
-      puts "#{ChefUtils::Dist::Infra::PRODUCT}: #{Chef::VERSION}"
+      puts "knife: #{Chef::Knife::VERSION}"
       puts
       puts "Docs: #{ChefUtils::Dist::Org::KNIFE_DOCS}"
       puts "Patents: #{ChefUtils::Dist::Org::PATENTS}"


### PR DESCRIPTION
Knife version should show knife version instead of Chef Infra Client version

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
