### PR TITLE
Fixing the path to update the version on merge

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -5,10 +5,6 @@
 slack:
   notify_channel: chef-ws-notify
 
-## This publish is triggered by the `built_in:publish_rubygems` artifact_action.
-#rubygems:
-#  - chef-cli
-
 release_branches:
   - main:
       version_constraint: 19.*

--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -6,7 +6,7 @@
 
 set -evx
 
-sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"$(cat VERSION)\"/" lib/knife/version.rb
+sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"$(cat VERSION)\"/" lib/chef/knife/version.rb
 
 # Once Expeditor finshes executing this script, it will commit the changes and push
 # the commit as a new tag corresponding to the value in the VERSION file.


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Fixing the path from lib/knife/version.rb to lib/chef/knife/version.rb to update the version on merge of PR

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
