### PR TITLE
Added base-2025-current, base-2025 and stable Channel for Promotion and RubyGems Publishing Workflow

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -78,21 +78,8 @@ subscriptions:
     actions:
      - built_in:promote_habitat_packages
 
-    # Promoting base-2025-current to base-2025
+  # Promoting base-2025-current to base-2025
   - workload: project_promoted:{{agent_id}}:*
     actions:
      - built_in:rollover_changelog
      - built_in:publish_rubygems
-
-
-  # # Promoting base-2025-current to base-2025
-  # - workload: project_promoted:{{agent_id}}:base-2025-current:*
-  #   actions:
-  #    - built_in:promote_habitat_packages
-
-  #  # Promoting base-2025 to stable
-  # - workload: project_promoted:{{agent_id}}:base-2025:*
-  #   actions:
-  #    - built_in:promote_habitat_packages
-  #    - built_in:rollover_changelog
-  #    - built_in:publish_rubygems


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

- Included base-2025-current, base-2025 and stable in the list of channels used for promotion.
- Enabled RubyGems publishing when promoting to the base-2025 and stable channel.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
