### PR TITLE
Modified plan.sh to install additional knife plugins during the package

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -54,11 +54,13 @@ do_unpack() {
 do_build() {
   export GEM_HOME="$pkg_prefix/vendor"
   export GEM_PATH="$GEM_HOME"
-  build_line "Building the Knife gem from the gemspec"
-
+  build_line "Building the Knife gem from the gemspec with GEM_HOME=$GEM_HOME and GEM_PATH=$GEM_PATH"
   pushd "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-    bundle config set --local path "$GEM_HOME"
-    bundle install --jobs=4 --retry=5
+    bundle config --local without integration deploy maintenance
+    bundle config --local jobs 4
+    bundle config --local retry 5
+    bundle config --local silence_root_warning 1
+    bundle install
 
     gem build knife.gemspec
 
@@ -67,9 +69,23 @@ do_build() {
 
 # Install the built gem into the package directory
 do_install() {
+   export GEM_HOME="$pkg_prefix/vendor"
+
+  build_line " do_install Setting GEM_PATH=$GEM_HOME"
+  export GEM_PATH="$GEM_HOME"
    build_line "Installing the Knife gem"
     pushd "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-    gem install knife-*.gem --no-document --install-dir "$GEM_HOME"
+    gem install knife-*.gem --no-document
+
+    # install additional knife plugins
+    gem install knife-azure --no-document
+    gem install knife-ec2 --no-document
+    gem install knife-google --no-document
+    gem install knife-windows --no-document --force
+    gem install knife-vrealize --no-document
+    gem install knife-vcenter --no-document
+    # Install knife-vsphere last with --force due to rbvmomi/rbvmomi2 executable conflict
+    gem install knife-vsphere --no-document --force
 
   popd
   wrap_ruby_knife
@@ -90,10 +106,13 @@ wrap_bin_with_ruby() {
 #!$(pkg_path_for core/bash)/bin/bash
 set -e
 # Set binary path that allows knife and chef to find correct binaries
-export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
-# Set Ruby gem paths to include the chef gem
-export GEM_HOME="$pkg_prefix/vendor/ruby/3.4.0"
-export GEM_PATH="\$GEM_HOME"
+export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:$pkg_prefix/vendor/bin:\$PATH"
+
+# Set Ruby paths defined from 'do_setup_environment()'
+export GEM_HOME="$pkg_prefix/vendor"
+export GEM_PATH="$GEM_PATH"
+
+
 exec $(pkg_path_for ${ruby_pkg})/bin/ruby $real_bin \$@
 EOF
   chmod -v 755 "$bin"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

Add installation of popular knife plugins to the habitat plan.sh build process.
This ensures that commonly used knife plugins are bundled with the knife habitat
package, providing a more complete out-of-the-box experience for users.

Plugins added:
- knife-vcenter: VMware vCenter integration
- knife-vrealize: VMware vRealize integration  
- knife-vsphere: VMware vSphere integration
- knife-azure: Microsoft Azure cloud integration
- knife-ec2: Amazon EC2 cloud integration
- knife-google: Google Cloud Platform integration
- knife-windows: Windows-specific knife functionality

Signed-off-by: Sachin <sachin.jain@chef.io>

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
