### PR TITLE
Fix undefined method 'blank?' error by using Ruby standard nil/empty

### DIFF
--- a/lib/chef/utils/licensing_handler.rb
+++ b/lib/chef/utils/licensing_handler.rb
@@ -33,7 +33,7 @@ class Chef
         def validate!
           license_keys = ChefLicensing.license_keys
 
-          return new(nil, nil) if license_keys.blank?
+          return new(nil, nil) if license_keys.nil? || license_keys.empty?
 
           licenses_metadata = ChefLicensing::Api::Describe.list({
             license_keys: license_keys,


### PR DESCRIPTION
This PR fixes an undefined method error where <code>blank?</code> is used without ActiveSupport being available. The fix replaces <code>.blank?</code> with explicit <code>nil</code> and <code>empty?</code> checks that are part of standard Ruby

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
