### PR TITLE
CHEF-15721: Add knife-azure plugin to habitat package

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -79,6 +79,11 @@ function Invoke-Build {
         Write-BuildLine " ** Installing built gem"
         gem install knife*.gem --no-document
 
+        Write-BuildLine "Installing the knife-azure plugin"
+        gem install specific_install
+        gem specific_install -l https://github.com/chef/knife-azure.git
+        If ($LASTEXITCODE -ne 0) { Exit $LASTEXITCODE }
+
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
     } finally {
         Pop-Location

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -88,6 +88,9 @@ do_install() {
     build_line "Installing the knife-google plugin"
     gem specific_install -l https://github.com/chef/knife-google.git -b sanjain/CHEF-15864/ruby_support_3.4
 
+    build_line "Installing the knife-azure plugin"
+    gem specific_install -l https://github.com/chef/knife-azure.git
+
   popd
   wrap_ruby_knife
   set_runtime_env "GEM_PATH" "${pkg_prefix}/vendor"


### PR DESCRIPTION
This PR adds knife-azure plugin to the knife habitat package, completing the second part of CHEF-15721 requirements. This work was completed with AI assistance following Progress AI policies.