### PR TITLE
CHEF-29677 - Sync knife features from chef/chef after 2025-01-15

### DIFF
--- a/lib/chef/knife/user_list.rb
+++ b/lib/chef/knife/user_list.rb
@@ -34,8 +34,22 @@ class Chef
         long: "--with-uri",
         description: "Show corresponding URIs."
 
+      option :all_users,
+             short: "-a",
+             long: "--all-users",
+             description: "Show all user details."
       def run
-        output(format_list_for_display(Chef::UserV1.list))
+        users = Chef::UserV1.list(config[:all_users])
+        if config[:all_users]
+          # When showing all user details, convert UserV1 objects to hashes for display
+          detailed_users = {}
+          users.each do |name, user|
+            detailed_users[name] = user.to_h
+          end
+          output(detailed_users)
+        else
+          output(format_list_for_display(users))
+        end
       end
 
     end


### PR DESCRIPTION
<h2>Summary</h2>
<p>This PR syncs knife feature changes from the chef/chef repository to the standalone knife repository for changes made after 2025-01-15.
</p>

<h2>Changes Made</h2>
<ul>
  <li>Enhanced user_list command with new features</li>
  <li>Added comprehensive unit tests for new functionality</li>
  <li>Synchronized feature implementations from knife 18 gem in chef/chef</li>
</ul>

<h2>Type of Change</h2>
<ul>
  <li>Feature enhancements</li>
  <li>Synchronization from chef/chef monorepo</li>
</ul>

<h2>Files Modified</h2>
<ul>
  <li><code>lib/chef/knife/user_list.rb</code> - Enhanced with new features (16 lines added)</li>
  <li><code>spec/unit/knife/user_list_spec.rb</code> - Added comprehensive tests (36 lines added)</li>
</ul>