### PR TITLE
CHEF-29678 - Sync Ruby 3.4 updates from chef/chef after 2025-01-15

### DIFF
--- a/knife.gemspec
+++ b/knife.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "license-acceptance", ">= 1.0.5", "< 3"
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
-  s.add_dependency "ffi", ">= 1.15" # 1.14 versions are broken on i386 windows
+  s.add_dependency "ffi", ">= 1.15", "< 1.18.0"
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "net-ssh", ">= 5.1", "< 8"
   s.add_dependency "net-ssh-multi", "~> 1.2", ">= 1.2.1"
@@ -29,7 +29,8 @@ Gem::Specification.new do |s|
   # disabling this until we get get it to compile on RHEL 7
   # s.add_dependency "x25519", ">= 1.0.9" # ed25519 KEX module. 1.0.9+ required to resolve sigill failures
   s.add_dependency "highline", ">= 1.6.9", "< 3" # Used in UI to present a list, no other usage.
-
+  s.add_dependency "abbrev"
+  
   s.add_dependency "tty-prompt", "~> 0.21" # knife ui.ask prompt
   s.add_dependency "tty-screen", "~> 0.6" # knife list
   s.add_dependency "tty-table", "~> 0.11" # knife render table output.

--- a/lib/chef/knife/acl_base.rb
+++ b/lib/chef/knife/acl_base.rb
@@ -26,7 +26,7 @@ class Chef
       PERM_TYPES = %w{create read update delete grant}.freeze unless defined? PERM_TYPES
       MEMBER_TYPES = %w{client group user}.freeze unless defined? MEMBER_TYPES
       OBJECT_TYPES = %w{clients containers cookbook_artifacts cookbooks data environments groups nodes roles policies policy_groups}.freeze unless defined? OBJECT_TYPES
-      OBJECT_NAME_SPEC = /^[\-[:alnum:]_\.]+$/.freeze unless defined? OBJECT_NAME_SPEC
+      OBJECT_NAME_SPEC = /^[\-[:alnum:]_\.]+$/ unless defined? OBJECT_NAME_SPEC
 
       def validate_object_type!(type)
         unless OBJECT_TYPES.include?(type)

--- a/lib/chef/knife/config_show.rb
+++ b/lib/chef/knife/config_show.rb
@@ -75,7 +75,7 @@ class Chef
               # It's a regex.
               filter_re = Regexp.new($1, $2 ? Regexp::IGNORECASE : 0)
               config_data.each do |key, value|
-                output_data[key] = value if key.to_s&.match?(filter_re)
+                output_data[key] = value if key.to_s.match?(filter_re)
               end
             else
               # It's a dotted path string.

--- a/lib/chef/knife/core/cookbook_scm_repo.rb
+++ b/lib/chef/knife/core/cookbook_scm_repo.rb
@@ -22,7 +22,7 @@ class Chef
   class Knife
     class CookbookSCMRepo
 
-      DIRTY_REPO = /^\s+M/.freeze
+      DIRTY_REPO = /^\s+M/
 
       include Chef::Mixin::ShellOut
 

--- a/lib/chef/knife/core/gem_glob_loader.rb
+++ b/lib/chef/knife/core/gem_glob_loader.rb
@@ -22,8 +22,8 @@ class Chef
   class Knife
     class SubcommandLoader
       class GemGlobLoader < Chef::Knife::SubcommandLoader
-        MATCHES_CHEF_GEM ||= %r{/chef-\d+\.\d+\.\d+}.freeze
-        MATCHES_THIS_CHEF_GEM ||= %r{/chef-#{Chef::VERSION}(-\w+)?(-\w+)?/}.freeze
+        MATCHES_CHEF_GEM ||= %r{/chef-\d+\.\d+\.\d+}
+        MATCHES_THIS_CHEF_GEM ||= %r{/chef-#{Chef::VERSION}(-\w+)?(-\w+)?/}
 
         def subcommand_files
           @subcommand_files ||= (gem_and_builtin_subcommands.values + site_subcommands).flatten.uniq

--- a/lib/chef/knife/environment_compare.rb
+++ b/lib/chef/knife/environment_compare.rb
@@ -107,7 +107,7 @@ class Chef
         cookbooks.each_key do |c|
           total = []
           environments.each { |n| total << constraints[n][c] }
-          if total.uniq.count == 1
+          if total.uniq.one?
             next if config[:mismatch]
 
             color = :white

--- a/spec/support/platforms/prof/gc.rb
+++ b/spec/support/platforms/prof/gc.rb
@@ -24,7 +24,7 @@ module RSpec
         # GC 1 invokes.
         # Index    Invoke Time(sec)       Use Size(byte)     Total Size(byte)         Total Object                    GC time(ms)
         #     1               0.012               159240               212940                10647         0.00000000000001530000
-        LINE_PATTERN = /^\s+([\d\.]*)\s+([\d\.]*)\s+([\d\.]*)\s+([\d\.]*)\s+([\d\.]*)\s+([\d\.]*)$/.freeze
+        LINE_PATTERN = /^\s+([\d\.]*)\s+([\d\.]*)\s+([\d\.]*)\s+([\d\.]*)\s+([\d\.]*)\s+([\d\.]*)$/
 
         def start
           ::GC::Profiler.enable unless ::GC::Profiler.enabled?


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<p>Syncs ruby 3.4 updates from knife gem in chef/chef to standalone knife repo. 
</p>

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
