### PR TITLE
Stop pulling Chef gems from Artifactory and use RubyGems instead

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -4,31 +4,13 @@
 
 set -ue
 
-echo "--- Current gem sources"
-gem source
-
 export USER="root"
 export LANG=C.UTF-8 LANGUAGE=C.UTF-8
 
-export ARTIFACTORY_ENDPOINT="https://artifactory-internal.ps.chef.co/artifactory"
-export ARTIFACTORY_USERNAME="REDACTED@chef.io"
+echo "--- bundle install"
 
-ruby_version=$(ruby -e 'puts RUBY_VERSION')
-echo "--- Detected Ruby version: $ruby_version"
-
-# Fix bundler double load on Ruby 3.1 by installing compatible RubyGems + Bundler
-if [[ "$ruby_version" == 3.1* ]]; then
-  echo "--- Installing RubyGems 3.6.9 for Ruby 3.1"
-  gem install rubygems-update -v 3.6.9
-  update_rubygems
-fi
-
-echo "--- Adding Artifactory gem source"
-gem source -a "${ARTIFACTORY_ENDPOINT}/api/gems/omnibus-gems-local" || true
-
-echo "--- Installing dependencies"
 bundle config --local path vendor/bundle
 bundle install --jobs=7 --retry=3
 
-echo "+++ Running bundle exec task"
+echo "+++ bundle exec task"
 bundle exec $@

--- a/.expeditor/run_windows_tests.ps1
+++ b/.expeditor/run_windows_tests.ps1
@@ -1,35 +1,10 @@
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference="stop"
 
-# TODO: Remove the download, rename, and move steps for the Chef gem to vendor/cache once the correct name is available in Artifactory or the gem gets published to the rubygems.org
-# This workaround is necessary because the Chef gem for Windows is currently published to the artifactory with an incorrect name.
-Write-Host "--- Configuring Artifactory access"
-$env:ARTIFACTORY_ENDPOINT = "https://artifactory-internal.ps.chef.co/artifactory"
-$env:ARTIFACTORY_USERNAME = "REDACTED@chef.io"
-$gem_source = "$env:ARTIFACTORY_ENDPOINT/api/gems/omnibus-gems-local"
+Write-Host "--- bundle install"
 
-Write-Host "--- Downloading Chef gem from Artifactory"
-$downloaded_path = "$env:TEMP\chef-19.1.116-universal-unknown.gem"
-Invoke-WebRequest -Uri "$gem_source/gems/chef-19.1.116-universal-unknown.gem" -OutFile $downloaded_path -UseBasicParsing
+bundle config --local path vendor/bundle
+bundle install --jobs=7 --retry=3 
 
-Write-Host "--- Renaming gem file to match correct platform"
-$corrected_path = "$env:TEMP\chef-19.1.116-universal-mingw-ucrt.gem"
-Rename-Item -Path $downloaded_path -NewName (Split-Path $corrected_path -Leaf)
-
-Write-Host "--- Moving gem to vendor/cache"
-$cache_path = "vendor/cache"
-if (!(Test-Path $cache_path)) { New-Item -ItemType Directory -Path $cache_path | Out-Null }
-Move-Item -Path $corrected_path -Destination "$cache_path/chef-19.1.116-universal-mingw-ucrt.gem" -Force
-
-Write-Host "--- Configuring bundler for Windows platform"
-bundle config set --local path vendor/bundle
-bundle config set --local force_ruby_platform false
-bundle config set --local no_prune true
-bundle lock --add-platform x64-mingw-ucrt
-
-Write-Host "--- Installing gems from Gemfile"
-bundle install --jobs=7 --retry=3
-if ($LASTEXITCODE -ne 0) { throw "Bundle install failed with exit code $LASTEXITCODE" }
-
-Write-Host "+++ Executing bundle exec task"
+Write-Host "+++ bundle exec task"
 bundle exec $args
 if ($LASTEXITCODE -ne 0) { throw "Command failed with exit code $LASTEXITCODE" }

--- a/Gemfile
+++ b/Gemfile
@@ -2,30 +2,14 @@ source "https://rubygems.org"
 
 gem "knife", path: "."
 
-# TODO: Once these gems are published to rubygems.org, we don't need to specify them in these conditions.
+gem "chef", ">= 19.1"
+gem "chef-config", ">= 19.1"
+gem "chef-utils", ">= 19.1"
+gem "ohai", ">= 19.1"
+
+# Windows-specific gems
 if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
   gem "appbundler"
-
-  # --- Windows: chef from vendor/cache, others from Artifactory ---
-
-  # Force Bundler to resolve chef from vendor/cache by declaring it without a source block
-  gem "chef", "19.1.116"
-
-  # Other Chef gems from Artifactory
-  source "https://artifactory-internal.ps.chef.co/artifactory/api/gems/omnibus-gems-local" do
-    gem "chef-config", "19.1.116"
-    gem "chef-utils", "19.1.116"
-    gem "ohai", ">= 19.1"
-  end
-
-else
-  # --- Linux/macOS: all Chef gems from Artifactory ---
-  source "https://artifactory-internal.ps.chef.co/artifactory/api/gems/omnibus-gems-local" do
-    gem "chef", ">= 19.1"
-    gem "chef-config", ">= 19.1"
-    gem "chef-utils", ">= 19.1"
-    gem "ohai", ">= 19.1"
-  end
 end
 
 # Only include these gems when Ruby version is 3.4.x

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -32,37 +32,11 @@ function Invoke-SetupEnvironment {
     Set-RuntimeEnv LC_CTYPE "en_US.UTF-8"
 }
 
-# Todo: Remove this function once the Chef gem is published with the correct name in Artifactory or rubygems.org.
-function Handle-ArtifactoryChefGem {
-    Write-Host "--- Handling temporary Chef gem workaround from Artifactory"
-
-    $gem_source = "https://artifactory-internal.ps.chef.co/artifactory/api/gems/omnibus-gems-local"
-    $downloaded_path = "$env:TEMP\chef-19.1.116-universal-unknown.gem"
-    $corrected_path = "$env:TEMP\chef-19.1.116-universal-mingw-ucrt.gem"
-    $cache_path = "$project_root/vendor/cache"
-
-    Write-Host "--- Downloading Chef gem from Artifactory"
-    Invoke-WebRequest -Uri "$gem_source/gems/chef-19.1.116-universal-unknown.gem" -OutFile $downloaded_path -UseBasicParsing
-
-    Write-Host "--- Renaming gem file to correct platform"
-    Rename-Item -Path $downloaded_path -NewName (Split-Path $corrected_path -Leaf)
-
-    Write-Host "--- Moving gem to vendor/cache"
-    if (!(Test-Path $cache_path)) {
-        New-Item -ItemType Directory -Path $cache_path | Out-Null
-    }
-    Move-Item -Path $corrected_path -Destination "$cache_path/chef-19.1.116-universal-mingw-ucrt.gem" -Force
-}
-
 function Invoke-Build {
     try {
         $env:Path += ";C:\Program Files\Git\bin"
         Push-Location $project_root
         $env:GEM_HOME = "$HAB_CACHE_SRC_PATH/$pkg_dirname/vendor"
-
-        # Add only the chef gem manually
-        # Todo: Remove this function once the Chef gem is published with the correct name in Artifactory or rubygems.org.
-        Handle-ArtifactoryChefGem
 
         Write-BuildLine " ** Configuring bundler for this build environment"
         bundle config --local without integration deploy maintenance


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Stop pulling Chef gems from Artifactory and use RubyGems instead
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
