### PR TITLE
[CHEF-33284] Fix spurious SERVER COMMANDS in knife --help

### DIFF
--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -102,17 +102,27 @@ class Chef
     def self.inherited(subclass)
       super
       unless subclass.unnamed?
+        caller_path = if subclass.superclass.to_s == "Chef::ChefFS::Knife"
+                        # ChefFS-based commands have a superclass that defines an
+                        # inherited method which calls super. This means that the
+                        # top of the call stack is not the class definition for
+                        # our subcommand.  Try the second entry in the call stack.
+                        path_from_caller(caller[1])
+                      else
+                        path_from_caller(caller[0])
+                      end
+
+        # Skip classes defined inside a subdirectory of chef/knife/ (e.g.
+        # chef/knife/cloud/server/create_command.rb). By convention, real knife
+        # subcommands live directly at chef/knife/<name>.rb — the same flat
+        # pattern that GemGlobLoader uses when discovering commands. Abstract
+        # base classes from plugins like knife-cloud are nested in subdirs and
+        # are only loaded transitively; registering them causes spurious
+        # categories (e.g. ** SERVER COMMANDS **) to appear in 'knife --help'.
+        return if caller_path.match?(%r{/chef/knife/[^/]+/})
+
         subcommands[subclass.snake_case_name] = subclass
-        subcommand_files[subclass.snake_case_name] +=
-          if subclass.superclass.to_s == "Chef::ChefFS::Knife"
-            # ChefFS-based commands have a superclass that defines an
-            # inherited method which calls super. This means that the
-            # top of the call stack is not the class definition for
-            # our subcommand.  Try the second entry in the call stack.
-            [path_from_caller(caller[1])]
-          else
-            [path_from_caller(caller[0])]
-          end
+        subcommand_files[subclass.snake_case_name] += [caller_path]
       end
     end
 


### PR DESCRIPTION
<h2>Summary</h2>
<p>Fixes <code>** SERVER COMMANDS **</code> appearing in <code>knife --help</code> with broken <code>Usage: knife (options)</code> banners, affecting any installation where <code>knife-cloud</code> (or similar plugins) are present — including chef-workstation and the knife hab package.</p>

<h2>Root Cause</h2>
<p>Plugins like <code>knife-cloud</code> define abstract base classes inside the <code>Chef::Knife</code> namespace in subdirectory files:</p>
<ul>
  <li><code>chef/knife/cloud/server/create_command.rb</code> → <code>Chef::Knife::Cloud::ServerCreateCommand</code></li>
  <li><code>chef/knife/cloud/server/delete_command.rb</code> → <code>Chef::Knife::Cloud::ServerDeleteCommand</code></li>
  <li><code>chef/knife/cloud/server/list_command.rb</code>   → <code>Chef::Knife::Cloud::ServerListCommand</code></li>
  <li><code>chef/knife/cloud/server/show_command.rb</code>   → <code>Chef::Knife::Cloud::ServerShowCommand</code></li>
</ul>
<p>These transitively inherit from <code>Chef::Knife</code>, so the <code>inherited</code> callback in <code>knife.rb</code> was unconditionally registering them as subcommands. Their <code>snake_case_name</code> resolves to <code>server_create_command</code> etc., giving them the category <code>server</code> → <code>** SERVER COMMANDS **</code> in <code>knife --help</code>.</p>
<p><code>GemGlobLoader</code> only discovers files matching <code>chef/knife/*.rb</code> (flat glob), but loading those real command files pulls in these abstract base classes as side effects — they were never meant to be registered as top-level knife subcommands.</p>

<h2>Fix</h2>
<p>In the <code>inherited</code> callback (<code>lib/chef/knife.rb</code>), extract the caller path and skip registration if the defining file lives inside a subdirectory of <code>chef/knife/</code>:</p>
<pre><code>return if caller_path.match?(%r{/chef/knife/[^/]+/})</code></pre>
<ul>
  <li><code>.../chef/knife/cloud/server/create_command.rb</code> → matches subdirectory pattern → <strong>skipped</strong></li>
  <li><code>.../chef/knife/google_server_create.rb</code> → no subdirectory → <strong>registered normally</strong></li>
  <li><code>spec/unit/knife_spec.rb</code> → outside chef/knife/ entirely → <strong>registered normally</strong></li>
</ul>
<p>This mirrors the convention already enforced by <code>GemGlobLoader</code>: real knife subcommands always live directly at <code>chef/knife/&lt;name&gt;.rb</code>.</p>

<h2>Testing</h2>
<ul>
  <li>Full test suite: <strong>2232 examples, 0 failures, 7 pending</strong></li>
  <li>Verified <code>knife --help</code> no longer shows <code>** SERVER COMMANDS **</code></li>
  <li>Real cloud plugin commands (e.g. <code>knife google server create</code>) remain fully functional — only the abstract base classes are excluded from registration</li>
</ul>

<h2>Files Modified</h2>
<ul>
  <li><code>lib/chef/knife.rb</code> — <code>inherited</code> callback now skips classes defined in <code>chef/knife/</code> subdirectories</li>
</ul>