### PR TITLE
Setup 'external' tests, add knife-windows

### DIFF
--- a/.github/workflows/gem_tests.yml
+++ b/.github/workflows/gem_tests.yml
@@ -1,0 +1,40 @@
+---
+name: gem_tests
+
+"on":
+  pull_request:
+    branches: [main, "chef-*"]
+  push:
+    branches: [main, "chef-*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gem-tests-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CHEF_LICENSE: accept-no-persist
+  FORCE_FFI_YAJL: ext
+
+jobs:
+  knife-windows:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: true
+      - name: Install native deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4.8"
+          bundler-cache: false
+      - name: Bundle install Knife
+        run: bundle install --jobs=3 --retry=3
+      - name: Run knife-windows tests
+        run: bundle exec tasks/bin/run_external_test chef/knife-windows main rake spec

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ binstubs/
 .idea
 
 bin/
+!tasks/bin/
 # ignore nodes generated during local testing
 # nodes/
 

--- a/tasks/bin/run_external_test
+++ b/tasks/bin/run_external_test
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+# This script helps to test external gems in the context of the current
+# Knife install. We want to make sure that the external gems will still function
+# once we release Knife so we run *their* specs against the current contents
+# of the knife repo. It lets us know if we need to update downstream
+# gems or fix regressions in knife *before* we release.
+
+$:.unshift(File.expand_path("../../lib", __dir__))
+
+require "tmpdir"
+require "bundler"
+require "chef/mixin/shell_out"
+
+include Chef::Mixin::ShellOut
+
+github_repo = ARGV.shift
+git_thing = ARGV.shift
+
+build_dir = Dir.pwd
+
+env = {
+  "GEMFILE_MOD" => "gem 'knife', path: '#{build_dir}'",
+  "CHEF_LICENSE" => "accept-no-persist",
+}
+
+Dir.mktmpdir("knife-external-test") do |dir|
+  git_url = "https://github.com/#{github_repo}"
+  Dir.rmdir dir
+  shell_out!("git clone #{git_url} #{dir}", live_stream: STDOUT)
+  Dir.chdir(dir) do
+    shell_out!("git checkout #{git_thing}", live_stream: STDOUT)
+    Bundler.with_unbundled_env do
+      shell_out!("bundle install --jobs=3 --retry=3", live_stream: STDOUT, env: env, timeout: 3600)
+      shell_out!("bundle exec #{ARGV.join(" ")}", live_stream: STDOUT, env: env)
+    end
+  end
+end


### PR DESCRIPTION
Chef still had external tests that pointing to knife-related
things, we need to move them here to nuke knife stuff from
chef/chef. Plus this still needs to be tested from here.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
