### PR TITLE
CHEF-31159 Setup common config to block PR merges if trufflehog fails

### DIFF
--- a/.github/workflows/ci-main-pull-request-stub-1.0.8.yml
+++ b/.github/workflows/ci-main-pull-request-stub-1.0.8.yml
@@ -104,6 +104,7 @@ jobs:
       # scc-output-filename: 'scc-output.txt'
       perform-language-linting: false    # Perform language-specific linting and pre-compilation checks
       perform-trufflehog-scan: true
+      fail-trufflehog-on-secrets-found: true
       perform-trivy-scan: true
 
       # grype vulnerability scanning


### PR DESCRIPTION
This PR updates the CI workflow configuration to block PR merges when Trufflehog detects secrets.

Added `fail-trufflehog-on-secrets-found: true` to fail builds when secrets are detected.