### PR TITLE
[DO NOT MERGE] GHCP — Crawl: Ex10 CI Baseline

### DIFF
--- a/.github/workflows/coverage-advisory.yml
+++ b/.github/workflows/coverage-advisory.yml
@@ -1,0 +1,77 @@
+---
+name: Coverage Advisory
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: coverage-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  coverage-summary:
+    name: Post coverage summary (advisory)
+    runs-on: ubuntu-22.04
+    # Non-blocking: this job never fails the PR even if coverage drops.
+    continue-on-error: true
+    env:
+      CHEF_LICENSE: accept-no-persist
+      FORCE_FFI_YAJL: ext
+      COVERAGE: "true"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install native deps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y libssl-dev libarchive-dev libffi-dev libyaml-dev
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: false
+
+      - name: Create unit test node fixtures
+        run: mkdir -p spec/data/nodes && touch spec/data/nodes/test.rb spec/data/nodes/default.rb spec/data/nodes/test.example.com.rb
+
+      - run: bundle install
+
+      - name: Run specs with coverage
+        run: bundle exec rake spec 2>&1 | tee /tmp/spec_output.txt
+
+      - name: Post coverage to job summary
+        if: always()
+        run: |
+          ruby - <<'RUBY'
+          output = File.read("/tmp/spec_output.txt")
+
+          # Parse SimpleCov line from output: "Line Coverage: 46.54% (3501 / 7522)"
+          line_match   = output.match(/Line Coverage:\s+([\d.]+)%\s+\((\d+)\s*\/\s*(\d+)\)/)
+          branch_match = output.match(/Branch Coverage:\s+([\d.]+)%\s+\((\d+)\s*\/\s*(\d+)\)/)
+          examples     = output.match(/(\d+) examples?, (\d+) failures?/)
+
+          line_pct   = line_match   ? line_match[1].to_f   : nil
+          branch_pct = branch_match ? branch_match[1].to_f : nil
+          threshold  = 80.0
+          status     = (line_pct && line_pct >= threshold) ? "✅" : "⚠️"
+
+          summary = <<~MD
+            ## #{status} Coverage Advisory (non-blocking)
+
+            | Metric | Value |
+            |--------|-------|
+            | Line coverage   | #{line_pct   ? "#{line_pct}%"   : "n/a"} |
+            | Branch coverage | #{branch_pct ? "#{branch_pct}%" : "n/a"} |
+            | Examples        | #{examples ? "#{examples[1]} examples, #{examples[2]} failures" : "n/a"} |
+            | Threshold       | #{threshold}% line coverage (advisory only) |
+
+            > This check is **advisory only** — it never blocks a merge.
+            > Threshold breaches surface visibility, not enforcement.
+          MD
+
+          File.open(ENV["GITHUB_STEP_SUMMARY"], "a") { |f| f.write(summary) }
+          puts summary
+          RUBY

--- a/ai-track-docs/ci-soft-gate.md
+++ b/ai-track-docs/ci-soft-gate.md
@@ -1,0 +1,53 @@
+# Ex10 — CI Soft Gating: Coverage Advisory
+
+## Goal
+Surface test coverage as evidence in CI without blocking merges.
+
+## What Was Added
+
+### `.github/workflows/coverage-advisory.yml`
+A new non-blocking workflow job (`continue-on-error: true`) that:
+1. Runs the full RSpec suite with `COVERAGE=true bundle exec rake spec`
+2. Parses SimpleCov's stdout (`Line Coverage: XX.XX% (N / M)`)
+3. Posts a markdown table to the GitHub job summary (`$GITHUB_STEP_SUMMARY`)
+
+### `spec/support/coverage.rb`
+Loads SimpleCov when `COVERAGE=true` is set:
+- Enables line + branch coverage
+- Filters `spec/` and `vendor/` from results
+- Tracks all `lib/**/*.rb` files
+
+### `spec/knife_spec_helper.rb`
+Added `require_relative "support/coverage"` before application requires — ensures SimpleCov instruments all loaded files.
+
+## Local Verification
+
+```bash
+COVERAGE=true bundle exec rake spec 2>&1 | grep "Coverage"
+# => Line Coverage: 47.26% (3558 / 7528)
+# => Branch Coverage: 21.76% (571 / 2624)
+```
+
+## CI Job Summary Output (example)
+
+| Metric | Value |
+|--------|-------|
+| Line coverage   | 47.26% |
+| Branch coverage | 21.76% |
+| Examples        | 2250 examples, 0 failures |
+| Threshold       | 80.0% line coverage (advisory only) |
+
+> This check is **advisory only** — it never blocks a merge.
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| `continue-on-error: true` | Ensures the job never gates a merge |
+| Parse stdout vs JSON file | SimpleCov 0.22 doesn't ship `JSONFormatter`; stdout is always written |
+| 80% threshold (advisory) | Reasonable target for a CLI gem; surfaced as ⚠️, not a failure |
+
+## Rollback
+```bash
+git revert HEAD  # removes coverage-advisory.yml and spec/support/coverage.rb
+```

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# scripts/run-tests.sh
+# Reusable local test script for knife development.
+# Mirrors what CI runs so results are reproducible locally.
+#
+# Usage:
+#   ./scripts/run-tests.sh            # run full suite
+#   ./scripts/run-tests.sh unit       # run unit tests only
+#   ./scripts/run-tests.sh spec/unit/knife/status_spec.rb  # run one file
+
+set -euo pipefail
+
+SUITE="${1:-all}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+export CHEF_LICENSE="accept-no-persist"
+export FORCE_FFI_YAJL="ext"
+
+echo "==> Installing dependencies..."
+bundle install --quiet
+
+echo "==> Creating test node fixtures..."
+mkdir -p spec/data/nodes
+touch spec/data/nodes/test.rb spec/data/nodes/default.rb spec/data/nodes/test.example.com.rb
+
+case "$SUITE" in
+  unit)
+    echo "==> Running unit tests..."
+    bundle exec rspec spec/unit/ --format progress
+    ;;
+  functional)
+    echo "==> Running functional tests..."
+    bundle exec rspec spec/functional/ --format progress
+    ;;
+  all)
+    echo "==> Running full test suite (rake spec)..."
+    bundle exec rake spec
+    ;;
+  *)
+    echo "==> Running: bundle exec rspec $SUITE"
+    bundle exec rspec "$SUITE" --format documentation
+    ;;
+esac
+
+echo ""
+echo "==> Done. All checks passed."

--- a/spec/knife_spec_helper.rb
+++ b/spec/knife_spec_helper.rb
@@ -29,9 +29,9 @@ require "rspec/mocks"
 require "rexml/document"
 require "webmock/rspec"
 
-require "chef/knife"
+require_relative "support/coverage"
 
-# cwd is knife/
+require "chef/knife"
 Dir["lib/chef/knife/**/*.rb"]
   .map { |f| f.gsub("lib/", "") }
   .map { |f| f.gsub(/\.rb$/, "") }

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# Loaded when COVERAGE=true env var is set (e.g., in CI advisory job).
+if ENV["COVERAGE"]
+  require "simplecov"
+
+  SimpleCov.start do
+    enable_coverage :branch
+    add_filter "/spec/"
+    add_filter "/vendor/"
+    track_files "lib/**/*.rb"
+  end
+end


### PR DESCRIPTION
## Summary
Added a reliable local test script (`scripts/run-tests.sh`) mirroring CI steps, plus a non-blocking coverage advisory CI workflow.

## Evidence
- `scripts/run-tests.sh` — supports `all`, `unit`, `functional`, or specific file
- `.github/workflows/coverage-advisory.yml` — non-blocking advisory job parsing SimpleCov stdout

## Review Focus
- `scripts/run-tests.sh` — verify it runs cleanly on macOS and Linux
- `.github/workflows/coverage-advisory.yml` — verify non-blocking (`continue-on-error: true`)

## Verification Steps
```bash
bash scripts/run-tests.sh unit
# Expect: N examples, 0 failures
bash scripts/run-tests.sh all
```

## Risk
Low — new script + advisory CI; no production code changed.

## Rollback
```bash
git revert HEAD
```