### PR TITLE
[DO NOT MERGE] GHCP -- Walk: Ex2 Build and Test Baseline (Coverage Surfacing)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,56 @@
 # Contributing to a Progress Chef Infra Client Project
 
 Thank you for your interest in contributing to this project! It is part of the larger Progress Chef Infra Client project. Contribution guidelines can be found at [Contributing to Progress Chef Infra Client](https://chef.github.io/chef-oss-practices/projects/chef/contributing/).
+
+## Running Tests
+
+```bash
+bundle install
+bundle exec rake spec
+```
+
+## Running Coverage Locally
+
+Coverage uses [SimpleCov](https://github.com/simplecov-ruby/simplecov) and is enabled via the `COVERAGE` environment variable.
+
+### Full suite with coverage
+
+```bash
+COVERAGE=true bundle exec rake spec
+```
+
+### Single file with coverage
+
+```bash
+COVERAGE=true bundle exec rspec spec/unit/knife/status_spec.rb
+```
+
+### Reading the output
+
+After the run completes, SimpleCov prints a summary to the terminal:
+
+```
+Line Coverage: 47.26% (3556 / 7524)
+Branch Coverage: 21.74% (571 / 2626)
+```
+
+An HTML report is also written to `coverage/index.html` — open it in a browser for a
+file-by-file breakdown.
+
+### Coverage threshold
+
+The advisory CI threshold is **80% line coverage**.  The check is non-blocking; it
+surfaces visibility without preventing merges.  See
+`.github/workflows/coverage-advisory.yml` for the full CI job.
+
+### Including coverage in a PR description
+
+When opening a PR, paste the SimpleCov terminal output into the **Evidence** section:
+
+```
+Evidence
+- Tests: 2253 examples, 0 failures
+- Line coverage:   47.26% (3556 / 7524)
+- Branch coverage: 21.74%  (571 / 2626)
+- Command: COVERAGE=true bundle exec rake spec
+```

--- a/ai-track-docs/coverage.md
+++ b/ai-track-docs/coverage.md
@@ -1,0 +1,70 @@
+# Coverage Baseline
+
+## Walk Ex2 — Build and Test Baseline
+
+### Tooling
+
+| Component | Detail |
+|-----------|--------|
+| Framework | RSpec |
+| Coverage gem | `simplecov 0.22.0` (line + branch) |
+| Activation | `COVERAGE=true` env var |
+| Config | `spec/support/coverage.rb` — loaded by `spec/knife_spec_helper.rb` |
+| CI job | `.github/workflows/coverage-advisory.yml` (advisory, non-blocking) |
+| HTML report | `coverage/index.html` (generated locally) |
+
+### Baseline Snapshot
+
+Captured on Walk Ex2 branch (`learn/walk/nikhil-ex2-coverage-surfacing`).
+
+```
+Command : COVERAGE=true bundle exec rake spec
+Examples: 2253 examples, 0 failures, 7 pending
+
+Line Coverage  : 47.26%  (3556 / 7524)
+Branch Coverage: 21.74%   (571 / 2626)
+```
+
+> The advisory threshold is 80% line coverage. Current baseline is below threshold —
+> this is expected for a mature CLI gem where many paths exercise the live Chef Server.
+> The advisory CI job surfaces the number without blocking merges.
+
+### Running Coverage Locally
+
+```bash
+# Full suite
+COVERAGE=true bundle exec rake spec
+
+# Single file (fast feedback)
+COVERAGE=true bundle exec rspec spec/unit/knife/status_spec.rb
+
+# Open HTML report after run
+open coverage/index.html
+```
+
+### PR Snippet Template
+
+Copy this block into the **Evidence** section of every PR that touches `lib/`:
+
+```
+Evidence
+- Tests: <N> examples, <N> failures
+- Line coverage:   <X>% (<covered> / <total>)
+- Branch coverage: <X>%  (<covered> / <total>)
+- Command: COVERAGE=true bundle exec rake spec
+```
+
+### How the CI Advisory Job Works
+
+`.github/workflows/coverage-advisory.yml`:
+1. Runs `COVERAGE=true bundle exec rake spec` and tees output to `/tmp/spec_output.txt`
+2. A Ruby inline script parses the SimpleCov terminal output
+3. Posts a Markdown table to the GitHub job summary (`$GITHUB_STEP_SUMMARY`)
+4. `continue-on-error: true` — the job never fails the PR
+
+### Adding New Coverage
+
+Focus areas with the lowest per-file coverage (visible in `coverage/index.html`):
+- `lib/chef/knife/core/` — presenter and loader helpers
+- `lib/chef/chef_fs/` — file system abstraction layer
+- Bootstrap templates in `lib/chef/knife/bootstrap/`

--- a/cspell.json
+++ b/cspell.json
@@ -17,6 +17,8 @@
     "abdulin",
     "erubis",
     "INTG",
+    "nikhil",
+    "simplecov",
     "libyajl2",
     "mermaid",
     "mmdc",


### PR DESCRIPTION
## Summary
- **What changed**: Surface coverage baseline and document how to run coverage locally
- **Plan**: Add coverage instructions to CONTRIBUTING.md + create coverage baseline snapshot in ai-track-docs/coverage.md
- **Files touched**:
  - \`CONTRIBUTING.md\` — added Running Tests + Running Coverage sections
  - \`ai-track-docs/coverage.md\` — new: baseline snapshot, PR snippet template, CI advisory job description

## Evidence
- Tests: 2253 examples, 0 failures, 7 pending
- Line coverage:   **47.26%** (3556 / 7524)
- Branch coverage: **21.74%** (571 / 2626)
- Command: \`COVERAGE=true bundle exec rake spec\`
- Coverage tool: SimpleCov 0.22.0 (already in Gemfile; activated via \`COVERAGE=true\`)

## Risk & Rollback
- Risk: **low** — documentation and test-helper wiring only; no production code changed
- Rollback: \`git revert a2f2a54\`

## Review Focus
- Confirm CONTRIBUTING.md coverage section is clear enough for a new contributor to run locally
- Verify coverage.md baseline snapshot matches expected output format
- Check that PR snippet template in coverage.md matches the CONTRIBUTING.md template

## Track
- Level: Walk
- Exercise: Ex2 — Build and Test Baseline (Coverage Surfacing)