### PR TITLE
[DO NOT MERGE] GHCP -- Walk: Ex3 Tiny Refactor (Behavior-Preserving)

### DIFF
--- a/lib/chef/knife/client_show.rb
+++ b/lib/chef/knife/client_show.rb
@@ -33,11 +33,7 @@ class Chef
       def run
         @client_name = @name_args[0]
 
-        if @client_name.nil?
-          show_usage
-          ui.fatal("You must specify a client name")
-          exit 1
-        end
+        test_mandatory_field(@client_name, "client name")
 
         client = Chef::ApiClientV1.load(@client_name)
         output(format_for_display(client))

--- a/lib/chef/knife/node_show.rb
+++ b/lib/chef/knife/node_show.rb
@@ -49,11 +49,7 @@ class Chef
         ui.use_presenter Knife::Core::NodePresenter
         @node_name = @name_args[0]
 
-        if @node_name.nil?
-          show_usage
-          ui.fatal("You must specify a node name")
-          exit 1
-        end
+        test_mandatory_field(@node_name, "node name")
 
         node = Chef::Node.load(@node_name)
         output(format_for_display(node))

--- a/lib/chef/knife/role_show.rb
+++ b/lib/chef/knife/role_show.rb
@@ -33,11 +33,7 @@ class Chef
       def run
         @role_name = @name_args[0]
 
-        if @role_name.nil?
-          show_usage
-          ui.fatal("You must specify a role name.")
-          exit 1
-        end
+        test_mandatory_field(@role_name, "role name")
 
         role = Chef::Role.load(@role_name)
         output(format_for_display(config[:environment] ? role.environment(config[:environment]) : role))


### PR DESCRIPTION
## Summary
- **What changed**: Replace duplicated 4-line nil-guard blocks in 3 show commands with the existing `test_mandatory_field` base-class helper
- **Plan**:
  - `Chef::Knife` base class already provides `test_mandatory_field(field, fieldname)` at `lib/chef/knife.rb:659`
  - Three show commands (`node_show`, `client_show`, `role_show`) each independently re-implement the same guard rather than calling it
  - Refactor: replace each inline block with one call to the existing helper
- **Files touched**:
  - `lib/chef/knife/node_show.rb` — 4-line block → `test_mandatory_field(@node_name, "node name")`
  - `lib/chef/knife/client_show.rb` — 4-line block → `test_mandatory_field(@client_name, "client name")`
  - `lib/chef/knife/role_show.rb` — 4-line block → `test_mandatory_field(@role_name, "role name")` (also removes trailing period inconsistency)
  - `lib/chef/knife.rb` — **unchanged** (helper already exists)

## Evidence
- Tests: 9 examples, 0 failures (targeted)
- Command: `bundle exec rspec spec/unit/knife/node_show_spec.rb spec/unit/knife/client_show_spec.rb spec/unit/knife/role_show_spec.rb`
- Diff: 3 files, +3 lines / −15 lines

## Risk & Rollback
- Risk: **low** — no behavior change; `test_mandatory_field` calls `show_usage`, `ui.fatal`, `exit 1` in the same order
- One minor normalization: role_show error message trailing period removed (`"role name."` → `"role name"`) for consistency
- Rollback: `git revert c93fb39`

## Review Focus
- Confirm `test_mandatory_field` in `lib/chef/knife.rb:659` is identical to the removed blocks
- Verify all 3 spec files still pass validation path tests
- Check that role_show error message change is acceptable

## Track
- Level: Walk
- Exercise: Ex3 — Tiny Refactor (Behavior-Preserving)