### PR TITLE
[DO NOT MERGE] GHCP -- Walk: Ex4 Documentation Sync (CONTRIBUTING and Onboarding)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,3 +54,91 @@ Evidence
 - Branch coverage: 21.74%  (571 / 2626)
 - Command: COVERAGE=true bundle exec rake spec
 ```
+
+## AI-Assisted Walk Track
+
+This repo includes a structured AI-assisted learning track.  The notes below
+describe the conventions used so contributors can follow the same pattern.
+
+### Plan First
+
+Before touching any code, write a plan:
+- List the files to change and why
+- Identify the test strategy
+- Note any risks or rollback path
+
+Ask Copilot to produce the plan, review it, then approve before implementation
+begins.  This produces reviewable evidence that the work was intentional.
+
+### Branching Strategy
+
+Branches are chained so context and artifacts build naturally:
+
+```
+main
+ └── learn/crawl/nikhil-ex0-bootstrap
+      └── learn/crawl/nikhil-ex1-...
+           └── ...
+                └── learn/walk/nikhil-ex1-architecture-map
+                     └── learn/walk/nikhil-ex2-coverage-surfacing
+                          └── learn/walk/nikhil-ex<N>-<slug>
+```
+
+- Each exercise branches from the previous exercise branch
+- PR base = previous exercise branch (keeps diffs focused)
+- Branch naming: `learn/walk/<name>-ex<N>-<slug>`
+
+### PR Expectations
+
+Every PR must include these sections:
+
+```
+Title: GHCP -- Walk: <ex#> <name>
+
+Summary
+- What changed and why
+- Plan: <inline summary or link>
+- Files/paths touched
+
+Evidence
+- Tests/logs/metrics: <commands + output summary>
+- Coverage: <percentage or contract evidence>
+
+Risk & Rollback
+- Risk: low/medium/high
+- Rollback: revert <commit SHA> or toggle <flag>
+
+Review Focus
+- Key areas for reviewer attention
+- Verification steps the reviewer can run
+
+Track
+- Level: Walk
+- Exercise: <ex#>
+```
+
+### DCO Sign-off
+
+All commits require a Developer Certificate of Origin sign-off:
+
+```bash
+git commit --signoff -m "message"
+# or
+git commit -s -m "message"
+```
+
+Builds will fail without it.
+
+### Using Copilot
+
+Recommended workflow per exercise:
+
+1. Paste the exercise block into Copilot Chat
+2. Ask: *"Write a plan before touching any code"*
+3. Review and approve the plan
+4. Ask Copilot to generate diffs file-by-file; review each before accepting
+5. Run tests and capture output for the PR Evidence section
+6. Commit (single Copilot-authored DCO-signed commit) and open PR
+
+See [docs/onboarding-walk.md](docs/onboarding-walk.md) for a ready-to-paste
+Copilot orientation prompt.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ knife bootstrap HOST -U USER -i IDENTITY_FILE --node-name NODE_NAME
 - [Official Knife Documentation](https://docs.chef.io/workstation/knife/)
 - [Setting up Knife](https://docs.chef.io/workstation/knife_setup/)
 - [Developer's Guide](docs/dev/README.md)
+- [Architecture Map](docs/architecture.md)
+- [Contributing](CONTRIBUTING.md)
+- [AI-Assisted Walk Track Onboarding](docs/onboarding-walk.md)
 
 ## Contributing
 

--- a/cspell.json
+++ b/cspell.json
@@ -16,6 +16,7 @@
     "abcz",
     "abdulin",
     "erubis",
+    "GHCP",
     "INTG",
     "nikhil",
     "simplecov",

--- a/docs/onboarding-walk.md
+++ b/docs/onboarding-walk.md
@@ -1,0 +1,130 @@
+# Onboarding Prompt — Walk Track
+
+> **How to use**: Paste this entire file into Copilot Chat at the start of a
+> new session to orient Copilot to the repo and the Walk track conventions.
+
+---
+
+## Repo at a Glance
+
+**Repo**: `chef/knife` — Ruby CLI gem that provides an interface between a
+local Chef repository and the Chef Infra Server.
+
+Key directories:
+```
+lib/chef/knife/          # Individual knife subcommands (e.g. node_show.rb)
+lib/chef/knife/core/     # Shared presenters, formatters, helpers
+lib/chef/knife.rb        # Base class — all subcommands inherit this
+lib/chef/application/knife.rb  # Entry point (bin/knife calls this)
+spec/unit/knife/         # RSpec unit tests, one file per command
+spec/functional/         # Functional tests
+ai-track-docs/           # Track documentation and exercise artifacts
+docs/                    # Architecture, onboarding, developer guide
+.github/workflows/       # CI: lint, DCO, specs, coverage-advisory, mermaid-lint
+```
+
+Tech stack: Ruby 3.1+, RSpec, SimpleCov, Rake, Bundler.
+
+---
+
+## Walk Track Rules
+
+1. **Plan first** — before touching any code, produce a written plan:
+   - Which files change and why
+   - Test strategy
+   - Risk and rollback path
+
+2. **Evidence-backed PRs** — every PR must include test output and coverage %
+
+3. **Chained branches** — each exercise branches from the previous:
+   ```
+   learn/walk/nikhil-ex1-architecture-map
+    └── learn/walk/nikhil-ex2-coverage-surfacing
+         └── learn/walk/nikhil-ex3-show-refactor
+              └── learn/walk/nikhil-ex<N>-<slug>
+   ```
+   PR base = previous exercise branch.
+
+4. **Single commit per exercise** — Copilot-authored, DCO-signed:
+   ```bash
+   GIT_AUTHOR_NAME="Copilot" \
+   GIT_AUTHOR_EMAIL="223556219+Copilot@users.noreply.github.com" \
+   git commit --signoff \
+     --trailer "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>" \
+     -m "Walk ExN: <description>"
+   ```
+
+5. **Labels**: `ai-assisted` + `[DO NOT MERGE]` in title.
+
+---
+
+## PR Template
+
+```
+Title: GHCP -- Walk: <ex#> <name>
+
+Summary
+- What changed and why
+- Plan: <inline summary>
+- Files/paths touched
+
+Evidence
+- Tests: <N> examples, <N> failures
+- Line coverage: <X>% (<covered> / <total>)
+- Command: COVERAGE=true bundle exec rake spec
+
+Risk & Rollback
+- Risk: low/medium/high
+- Rollback: revert <commit SHA>
+
+Review Focus
+- Key areas for reviewer attention
+- Verification steps the reviewer can run
+
+Track
+- Level: Walk
+- Exercise: <ex#>
+```
+
+---
+
+## Key Commands
+
+```bash
+# Install dependencies
+bundle install
+
+# Run all tests
+bundle exec rake spec
+
+# Run single spec file
+bundle exec rspec spec/unit/knife/<command>_spec.rb
+
+# Run tests with coverage
+COVERAGE=true bundle exec rake spec
+
+# Check spelling (same check as CI)
+npx cspell "**/*.md" --no-progress
+```
+
+---
+
+## CI Checks
+
+| Workflow | What it checks |
+|----------|---------------|
+| `lint.yml` | cspell spellcheck on all `.md` files |
+| `dco.yml` | DCO sign-off on every commit |
+| `unit_specs.yml` | Full RSpec suite |
+| `coverage-advisory.yml` | SimpleCov line/branch % (advisory, non-blocking) |
+| `mermaid-lint.yml` | Validates `.mmd` diagram files render |
+
+---
+
+## Further Reading
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — branching, PR format, DCO, Walk workflow
+- [docs/dev/README.md](dev/README.md) — execution flow, bootstrap, plugins
+- [docs/architecture.md](architecture.md) — node→path map and data flows
+- [ai-track-docs/SYSTEM-OVERVIEW.md](../ai-track-docs/SYSTEM-OVERVIEW.md) — system overview
+- [ai-track-docs/coverage.md](../ai-track-docs/coverage.md) — coverage baseline and PR snippet


### PR DESCRIPTION
## Summary
- **What changed**: Sync CONTRIBUTING.md with Walk workflow conventions and add a ready-to-paste Copilot onboarding prompt
- **Plan**: CONTRIBUTING.md had Running Tests + Coverage (from Ex2) but nothing about branching, PR format, or the Walk workflow. Added Walk section there, created onboarding prompt, and linked both from README.
- **Files touched**:
  - \`CONTRIBUTING.md\` — appended "AI-Assisted Walk Track" section (plan-first rule, branching strategy, PR expectations, DCO requirement, Copilot usage steps)
  - \`docs/onboarding-walk.md\` — new: single-page paste-into-Copilot orientation prompt (repo overview, Walk rules, PR template, key commands, CI check table)
  - \`README.md\` — added Architecture Map, Contributing, and Onboarding links to Documentation section

## Evidence
- No production code changed; no test run required
- Verified no British spellings in changed files
- Verified all new terms (`nikhil`, `simplecov`, `mermaid`) already present in `cspell.json`

## Risk & Rollback
- Risk: **low** — documentation only; no production code or test changes
- Rollback: \`git revert bc02931\`

## Review Focus
- \`docs/onboarding-walk.md\` — confirm it is concise enough to paste into a single Copilot session and covers all Walk conventions
- \`CONTRIBUTING.md\` Walk section — confirm PR template and branching strategy match actual exercise history
- \`README.md\` links — confirm they resolve correctly

## Track
- Level: Walk
- Exercise: Ex4 — Documentation Sync (CONTRIBUTING and Onboarding)