### PR TITLE
[DO NOT MERGE] GHCP -- Walk: Ex5 API/Contract Hardening (Contract Tests at a Boundary)

### DIFF
--- a/ai-track-docs/contract-test.md
+++ b/ai-track-docs/contract-test.md
@@ -1,0 +1,72 @@
+# Contract Test: StatusPresenter JSON Output
+
+## Walk Ex5 — API/Contract Hardening
+
+### Contract Surface
+
+**Method**: `Chef::Knife::Core::StatusPresenter#summarize_json(list)`  
+**File**: `lib/chef/knife/core/status_presenter.rb`  
+**Consumer**: `knife status --format json`
+
+This method is the JSON API boundary between the knife status command and any
+consumer that parses its output (scripts, dashboards, CI checks).
+
+### Guaranteed Fields (always present)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | String | Node name |
+| `chef_environment` | String / nil | Chef environment assignment |
+| `ohai_time` | Numeric | Unix timestamp of last check-in |
+
+### Optional Fields (present only when data exists)
+
+| Field | Present when | Key name (do not rename) |
+|-------|-------------|--------------------------|
+| `ip` | Node has `ipaddress` or cloud public IPv4 | `ip` (not `ipaddress`) |
+| `fqdn` | Node has `fqdn` or cloud public hostname | `fqdn` |
+| `platform` | Node has `platform` attribute | `platform` |
+| `platform_version` | Node has `platform_version` attribute | `platform_version` |
+| `run_list` | `--run-list` flag passed | `run_list` |
+| `default` / `override` / `automatic` | `--long-output` flag passed | attribute hashes |
+
+### Golden File
+
+`spec/data/status_presenter_contract.json` — snapshot of a fully-populated
+node with `run_list` and `long_output` disabled (default invocation). The
+`ohai_time` value is fixed to `0` to prevent timestamp drift.
+
+### Running the Contract Tests
+
+```bash
+bundle exec rspec spec/unit/knife/core/status_presenter_spec.rb
+```
+
+The contract tests live in the `describe "contract: summarize_json output schema"` block.
+
+### Updating the Contract Intentionally
+
+If `summarize_json` is modified in a way that changes the output shape (e.g., a
+field is renamed, added, or removed), follow these steps:
+
+1. Make the code change in `lib/chef/knife/core/status_presenter.rb`
+2. Run the specs — the golden file test will fail with a diff showing exactly what changed
+3. Review the diff: confirm the change is intentional and not a regression
+4. Regenerate the golden file:
+   ```bash
+   bundle exec rspec spec/unit/knife/core/status_presenter_spec.rb \
+     -e "matches the golden file snapshot" --format documentation
+   ```
+   Then update `spec/data/status_presenter_contract.json` to match the new output
+5. Update the **Guaranteed Fields** or **Optional Fields** tables above
+6. Call out the schema change explicitly in the PR description under a
+   "Contract Change" heading so reviewers know it is intentional
+
+### What Counts as a Breaking Change
+
+- Renaming a guaranteed field (e.g., `ohai_time` → `last_seen`)
+- Removing a guaranteed field
+- Changing the type of a guaranteed field (e.g., `ohai_time` from Numeric to String)
+- Renaming an optional field (e.g., `ip` → `ipaddress`)
+
+Breaking changes should be called out in the CHANGELOG and PR description.

--- a/spec/data/status_presenter_contract.json
+++ b/spec/data/status_presenter_contract.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "contract-node",
+    "chef_environment": "production",
+    "ip": "10.0.0.1",
+    "fqdn": "contract-node.example.com",
+    "ohai_time": 0,
+    "platform": "ubuntu",
+    "platform_version": "22.04"
+  }
+]

--- a/spec/unit/knife/core/status_presenter_spec.rb
+++ b/spec/unit/knife/core/status_presenter_spec.rb
@@ -50,5 +50,98 @@ describe Chef::Knife::Core::StatusPresenter do
     it "falls back to ipaddress when cloud attributes is not present" do
       expect(result["ip"]).to eq("127.0.0.1")
     end
+
+    # ------------------------------------------------------------------
+    # Contract tests — validate the guaranteed JSON shape of summarize_json.
+    # These tests define the public API contract for consumers of
+    # `knife status --format json`. If any of these fail after a code change,
+    # update the golden file and this describe block intentionally and
+    # document the breaking change in the PR. See ai-track-docs/contract-test.md.
+    # ------------------------------------------------------------------
+    describe "contract: summarize_json output schema" do
+      # Controlled config: run_list and long_output explicitly off so the
+      # contract tests cover the stable default output shape only.
+      let(:contract_config) do
+        cfg = double(:config)
+        allow(cfg).to receive(:[]).and_return(nil)
+        allow(cfg).to receive(:[]).with("run_list").and_return(false)
+        allow(cfg).to receive(:[]).with(:run_list).and_return(false)
+        allow(cfg).to receive(:[]).with(:long_output).and_return(false)
+        cfg
+      end
+      let(:contract_presenter) { Chef::Knife::Core::StatusPresenter.new(double(:ui), contract_config) }
+
+      let(:full_node) do
+        Chef::Node.new.tap do |n|
+          n.automatic_attrs["name"]             = "contract-node"
+          n.automatic_attrs["chef_environment"] = "production"
+          n.automatic_attrs["ohai_time"]        = 0
+          n.automatic_attrs["ipaddress"]        = "10.0.0.1"
+          n.automatic_attrs["fqdn"]             = "contract-node.example.com"
+          n.automatic_attrs["platform"]         = "ubuntu"
+          n.automatic_attrs["platform_version"] = "22.04"
+        end
+      end
+
+      let(:full_result) { JSON.parse(contract_presenter.summarize_json([full_node])).first }
+
+      it "returns valid JSON that parses to an Array" do
+        raw = contract_presenter.summarize_json([full_node])
+        parsed = JSON.parse(raw)
+        expect(parsed).to be_a(Array)
+      end
+
+      it "always includes the required field: name (String)" do
+        expect(full_result).to have_key("name")
+        expect(full_result["name"]).to be_a(String)
+      end
+
+      it "always includes the required field: chef_environment" do
+        expect(full_result).to have_key("chef_environment")
+      end
+
+      it "always includes the required field: ohai_time (Numeric)" do
+        expect(full_result).to have_key("ohai_time")
+        expect(full_result["ohai_time"]).to be_a(Numeric)
+      end
+
+      it "includes ip when ipaddress is present, using key 'ip' not 'ipaddress'" do
+        expect(full_result).to have_key("ip")
+        expect(full_result).not_to have_key("ipaddress")
+      end
+
+      it "includes fqdn when fqdn attribute is present, using key 'fqdn'" do
+        expect(full_result).to have_key("fqdn")
+      end
+
+      it "includes platform when present" do
+        expect(full_result).to have_key("platform")
+        expect(full_result["platform"]).to eq("ubuntu")
+      end
+
+      it "includes platform_version when present" do
+        expect(full_result).to have_key("platform_version")
+        expect(full_result["platform_version"]).to eq("22.04")
+      end
+
+      it "omits ip when no ipaddress and no cloud data" do
+        bare_node = Chef::Node.new.tap { |n| n.automatic_attrs["name"] = "bare" }
+        result = JSON.parse(contract_presenter.summarize_json([bare_node])).first
+        expect(result).not_to have_key("ip")
+      end
+
+      it "omits platform when not set" do
+        bare_node = Chef::Node.new.tap { |n| n.automatic_attrs["name"] = "bare" }
+        result = JSON.parse(contract_presenter.summarize_json([bare_node])).first
+        expect(result).not_to have_key("platform")
+      end
+
+      it "matches the golden file snapshot" do
+        golden_path = File.expand_path("../../../data/status_presenter_contract.json", __dir__)
+        golden = JSON.parse(File.read(golden_path))
+        actual = JSON.parse(contract_presenter.summarize_json([full_node]))
+        expect(actual).to eq(golden)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- **What changed**: Add contract tests for `StatusPresenter#summarize_json` — the JSON boundary consumed by `knife status --format json`
- **Plan**:
  - Identified `StatusPresenter#summarize_json` as the clearest API boundary (3 guaranteed fields, 5 optional, existing spec already parses JSON)
  - Added `describe "contract"` block with 11 assertions covering required fields, types, optional present/absent, JSON validity, and golden file comparison
  - Created golden file at `spec/data/status_presenter_contract.json` with `ohai_time: 0` to avoid timestamp drift
  - Documented the contract and update procedure in `ai-track-docs/contract-test.md`
- **Files touched**:
  - `spec/unit/knife/core/status_presenter_spec.rb` — added contract describe block
  - `spec/data/status_presenter_contract.json` — new golden snapshot
  - `ai-track-docs/contract-test.md` — new: contract surface, update instructions

## Evidence
- Tests: 15 examples, 0 failures
- Command: `bundle exec rspec spec/unit/knife/core/status_presenter_spec.rb`
- Contract assertions: required fields (name/chef_environment/ohai_time), field types, optional fields present/absent, JSON validity, golden file match

## Risk & Rollback
- Risk: **low** — new tests only; no production code changed
- Rollback: `git revert 5653c0c`

## Review Focus
- `contract-test.md` — confirm update instructions are clear enough for a developer to follow when changing the schema intentionally
- `status_presenter_spec.rb` contract block — confirm the controlled config double correctly disables `run_list` and `long_output` for a stable golden file
- Golden file — confirm field list matches the stable default output shape

## Track
- Level: Walk
- Exercise: Ex5 — API/Contract Hardening (Contract Tests at a Boundary)