### PR TITLE
[DO NOT MERGE] GHCP -- Walk: Ex6 Performance Touch-point (Micro-Optimization with Evidence)

### DIFF
--- a/ai-track-docs/perf-optimization.md
+++ b/ai-track-docs/perf-optimization.md
@@ -97,3 +97,70 @@ Chef::Knife::Status
 ```bash
 git revert HEAD  # removes constant + restores inline hash allocation
 ```
+
+---
+
+## Walk Ex6 — Micro-Optimization: StatusPresenter#summarize String Building
+
+### Candidates
+
+**File**: `lib/chef/knife/core/status_presenter.rb`, `summarize` method
+
+#### 1. O(n²) string concatenation (line 123)
+
+Before:
+```ruby
+summarized = "#{summarized}#{line_parts.join(", ")}.\n"
+```
+Each iteration allocates a new string that copies the entire accumulated result.
+This is O(n²) in the number of nodes displayed.
+
+After:
+```ruby
+summarized << "#{line_parts.join(", ")}.\n"
+```
+Shovel operator appends in-place. O(1) per node — O(n) total.
+
+#### 2. Redundant `.dup` allocation (lines 119-121)
+
+Before:
+```ruby
+platform = node["platform"].dup
+if node["platform_version"]
+  platform << " #{node["platform_version"]}"
+end
+```
+`.dup` copies the string only to potentially discard the copy. The `<<` mutates
+the copy, not the original attribute — the `.dup` is unnecessary defensive code.
+
+After:
+```ruby
+platform = if node["platform_version"]
+               "#{node["platform"]} #{node["platform_version"]}"
+             else
+               node["platform"]
+             end
+```
+Single allocation, no copy.
+
+### Benchmark Evidence
+
+Measured with `Benchmark.bm` on inline Ruby, simulating the concat loop:
+
+| n nodes | Before (concat) | After (shovel) | Speedup |
+|---------|----------------|----------------|---------|
+| 1 000   | 0.051 ms       | 0.033 ms       | 1.5×    |
+| 10 000  | 2.628 ms       | 0.321 ms       | **8.2×** |
+
+### Safety
+
+- Both changes are behavior-preserving; output is identical.
+- 38 existing spec examples (status_spec + status_presenter_spec) remain green.
+- The optimization matters most for large fleets (1 000+ nodes) where
+  `knife status` output is piped to scripts.
+
+### Rollback
+
+```bash
+git revert HEAD  # reverts both lines in a single commit
+```

--- a/lib/chef/knife/core/status_presenter.rb
+++ b/lib/chef/knife/core/status_presenter.rb
@@ -113,14 +113,15 @@ class Chef
             line_parts << run_list.to_s if run_list
 
             if node["platform"]
-              platform = node["platform"].dup
-              if node["platform_version"]
-                platform << " #{node["platform_version"]}"
-              end
+              platform = if node["platform_version"]
+                           "#{node["platform"]} #{node["platform_version"]}"
+                         else
+                           node["platform"]
+                         end
               line_parts << platform
             end
 
-            summarized = "#{summarized}#{line_parts.join(", ")}.\n"
+            summarized << "#{line_parts.join(", ")}.\n"
           end
           summarized
         end


### PR DESCRIPTION
## Summary
- **What changed**: Two micro-optimizations in `StatusPresenter#summarize` — O(n²) string concat replaced with O(1) shovel append; redundant `.dup` allocation removed
- **Plan**:
  - Identified O(n²) pattern on line 123: `summarized = "#{summarized}#{...}"` copies entire string every iteration
  - Identified redundant `.dup` on lines 119–121: copy is made then immediately discarded
  - Both fixes are behavior-preserving; output identical
- **Files touched**:
  - `lib/chef/knife/core/status_presenter.rb` — 2 targeted changes in `summarize` method
  - `ai-track-docs/perf-optimization.md` — appended Walk Ex6 benchmark section

## Evidence

### Before/After Benchmark

| n nodes | Before (concat) | After (shovel) | Speedup |
|---------|----------------|----------------|---------|
| 1 000   | 0.051 ms       | 0.033 ms       | 1.5×    |
| 10 000  | 2.628 ms       | 0.321 ms       | **8.2×** |

Command: `bundle exec ruby -e "require 'benchmark'; ..."` (inline timing of the concat loop)

### Tests
- 38 examples, 0 failures
- Command: `bundle exec rspec spec/unit/knife/core/status_presenter_spec.rb spec/unit/knife/status_spec.rb`

## Risk & Rollback
- Risk: **low** — no logic change; shovel and concat produce identical strings; interpolation replaces `.dup + <<`
- Rollback: `git revert 3d99519`

## Review Focus
- Confirm `summarized << "..."` produces identical output to `summarized = "#{summarized}..."` for all node configurations
- Confirm platform string interpolation handles `platform_version` nil case correctly (new `else` branch returns `node["platform"]` unchanged)

## Track
- Level: Walk
- Exercise: Ex6 — Performance Touch-point (Micro-Optimization with Evidence)