### PR TITLE
[DO NOT MERGE] GHCP -- Walk: Ex7 Dependency Hygiene (Minor Dependency Upgrade)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,7 +189,7 @@ GEM
       logger
     faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
-    faraday-http-cache (2.6.1)
+    faraday-http-cache (2.7.0)
       faraday (>= 0.8)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)

--- a/ai-track-docs/dep-upgrade.md
+++ b/ai-track-docs/dep-upgrade.md
@@ -68,3 +68,60 @@ bundle install
 git checkout HEAD~1 -- Gemfile.lock
 bundle install
 ```
+
+---
+
+## Walk Ex7 — Minor Upgrade: faraday-http-cache 2.6.1 → 2.7.0
+
+### Upgrade Summary
+
+| | Before | After |
+|-|--------|-------|
+| Gem | `faraday-http-cache` | `faraday-http-cache` |
+| Version | 2.6.1 | 2.7.0 |
+| Type | indirect dependency (HTTP caching middleware for faraday) |  |
+| Code changes | none | none |
+
+### Rationale
+
+`faraday-http-cache` is an HTTP caching middleware layer. Knife does not call
+it directly — it is pulled in transitively. The 2.7.0 release maintains the
+same `faraday >= 0.8` runtime requirement already satisfied by `faraday 2.14.1`.
+
+Minor upgrade (2.6 → 2.7) is safe: no API surface knife code calls changed.
+
+### How the Upgrade Was Applied
+
+```bash
+bundle update faraday-http-cache --conservative
+```
+
+The `--conservative` flag ensures only `faraday-http-cache` moves in
+`Gemfile.lock`. All other gems remain pinned. The lock diff was exactly one
+line:
+
+```diff
+-    faraday-http-cache (2.6.1)
++    faraday-http-cache (2.7.0)
+```
+
+### Test Evidence
+
+```
+Command: bundle exec rake spec
+Result:  2264 examples, 0 failures, 7 pending
+```
+
+### Rollback
+
+```bash
+# Pin back to previous version in Gemfile.lock
+git checkout HEAD~1 -- Gemfile.lock
+bundle install
+```
+
+Or explicitly pin in Gemfile:
+
+```ruby
+gem "faraday-http-cache", "2.6.1"
+```


### PR DESCRIPTION
## Summary
- **What changed**: Upgraded `faraday-http-cache` from 2.6.1 to 2.7.0 in `Gemfile.lock`
- **Plan**:
  - Ran \`bundle outdated\` to list candidates
  - Selected \`faraday-http-cache\` (minor bump, indirect dep, zero knife code surface)
  - Applied with \`bundle update faraday-http-cache --conservative\` to pin all other gems
  - Lock diff: exactly 1 line changed
  - No production code changes required
- **Files touched**:
  - \`Gemfile.lock\` — single version line changed
  - \`ai-track-docs/dep-upgrade.md\` — appended Walk Ex7 section

## Evidence
- Lock diff: `-faraday-http-cache (2.6.1)` → `+faraday-http-cache (2.7.0)` — 1 line only
- Tests: **2264 examples, 0 failures, 7 pending** (full suite: \`bundle exec rake spec\`)

## Risk & Rollback
- Risk: **low** — indirect dep, no knife code calls it directly, same faraday `>= 0.8` requirement already satisfied
- Rollback:
  ```bash
  git checkout HEAD~1 -- Gemfile.lock
  bundle install
  ```

## Review Focus
- Confirm `Gemfile.lock` diff touches only `faraday-http-cache`
- Confirm test count matches baseline (2253 → 2264 is expected, +11 from Walk Ex5 contract tests added to the chain)

## Track
- Level: Walk
- Exercise: Ex7 — Dependency Hygiene (Minor Dependency Upgrade)