### PR TITLE
[DO NOT MERGE] GHCP -- Walk: Ex9 Observability Enhancement

### DIFF
--- a/ai-track-docs/observability.md
+++ b/ai-track-docs/observability.md
@@ -90,3 +90,65 @@ bundle exec rspec spec/unit/knife/status_spec.rb --format documentation
 ```bash
 git revert HEAD  # removes timing instrumentation and tests
 ```
+
+---
+
+## Walk Ex9 — Observability Enhancement
+
+### Changes
+
+**Improvement 1: Promote `knife status` timing to unconditional `debug` level**
+
+Before (Crawl Ex9): the structured log line only emitted when `KNIFE_TIMING=1` was set.
+After (Walk Ex9): always emitted at `Chef::Log.debug` so standard `--log-level debug` works.
+`KNIFE_TIMING` still triggers an additional `info`-level line for CI/scripting compatibility.
+
+```ruby
+# Always visible at debug level:
+Chef::Log.debug("op=knife_status status=ok nodes=N elapsed_ms=T")
+# Also at info when KNIFE_TIMING=1:
+Chef::Log.info("op=knife_status status=ok nodes=N elapsed_ms=T") if ENV["KNIFE_TIMING"]
+```
+
+**Improvement 2: Add load-time timing to `knife node show`**
+
+`lib/chef/knife/node_show.rb` now wraps `Chef::Node.load` with a monotonic clock and emits:
+
+```ruby
+Chef::Log.debug("op=knife_node_show status=ok node=NAME elapsed_ms=T")
+```
+
+### Verification
+
+```bash
+# knife status — always visible at debug level (no env var needed)
+knife status --log-level debug 2>&1 | grep op=knife_status
+
+# Expected output on stderr:
+# DEBUG: op=knife_status status=ok nodes=42 elapsed_ms=123
+
+# knife node show — new hook
+knife node show mynode --log-level debug 2>&1 | grep op=knife_node_show
+
+# Expected output on stderr:
+# DEBUG: op=knife_node_show status=ok node=mynode elapsed_ms=45
+```
+
+### Risk Notes
+
+| Risk | Mitigation |
+|------|-----------|
+| `debug` verbosity | `debug` level is off by default; only visible when explicitly requested |
+| `KNIFE_TIMING` behavior change | Still triggers `info`-level log — backward compatible |
+| `node_show` timing overhead | Sub-microsecond monotonic clock read — no measurable impact |
+
+### Test Coverage
+
+- `spec/unit/knife/status_spec.rb`: updated to assert `Chef::Log.debug` called unconditionally; `info` only when `KNIFE_TIMING` set
+- `spec/unit/knife/node_show_spec.rb`: new example asserts `Chef::Log.debug` called with `op=knife_node_show` pattern
+
+### Rollback
+
+```bash
+git revert HEAD
+```

--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,7 @@
   // words - list of words to be always considered correct
   "words": [
     "abcz",
+    "mynode",
     "abdulin",
     "erubis",
     "GHCP",

--- a/lib/chef/knife/node_show.rb
+++ b/lib/chef/knife/node_show.rb
@@ -51,7 +51,10 @@ class Chef
 
         test_mandatory_field(@node_name, "node name")
 
+        load_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         node = Chef::Node.load(@node_name)
+        load_elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - load_start
+        Chef::Log.debug("op=knife_node_show status=ok node=#{@node_name} elapsed_ms=#{(load_elapsed * 1000).round}")
         output(format_for_display(node))
       end
     end

--- a/lib/chef/knife/status.rb
+++ b/lib/chef/knife/status.rb
@@ -87,6 +87,7 @@ class Chef
           exit 1
         end
 
+        Chef::Log.debug("op=knife_status status=ok nodes=#{all_nodes.size} elapsed_ms=#{(search_elapsed * 1000).round}")
         if ENV["KNIFE_TIMING"]
           Chef::Log.info("op=knife_status status=ok nodes=#{all_nodes.size} elapsed_ms=#{(search_elapsed * 1000).round}")
         end

--- a/spec/unit/knife/node_show_spec.rb
+++ b/spec/unit/knife/node_show_spec.rb
@@ -44,6 +44,13 @@ describe Chef::Knife::NodeShow do
       knife.run
     end
 
+    it "logs load-time duration at debug level" do
+      allow(Chef::Node).to receive(:load).with("adam").and_return(node)
+      allow(knife).to receive(:output)
+      expect(Chef::Log).to receive(:debug).with(/op=knife_node_show status=ok node=adam elapsed_ms=\d+/)
+      knife.run
+    end
+
     it "should pretty print the node, formatted for display" do
       knife.config[:format] = nil
       stdout = StringIO.new

--- a/spec/unit/knife/status_spec.rb
+++ b/spec/unit/knife/status_spec.rb
@@ -171,12 +171,13 @@ describe Chef::Knife::Status do
     end
   end
 
-  describe "structured log hook (KNIFE_TIMING flag)" do
+  describe "structured log hook" do
     context "when KNIFE_TIMING is set" do
       around { |ex| ENV["KNIFE_TIMING"] = "1"; ex.run; ENV.delete("KNIFE_TIMING") }
 
       it "logs structured fields after search completes" do
         expect(Chef::Log).to receive(:info).with(/Sending query/)
+        expect(Chef::Log).to receive(:debug).with(/op=knife_status status=ok nodes=1 elapsed_ms=\d+/)
         expect(Chef::Log).to receive(:info).with(/op=knife_status status=ok nodes=1 elapsed_ms=\d+/)
         @knife.run
       end
@@ -184,16 +185,19 @@ describe Chef::Knife::Status do
       it "logs 0 nodes in structured format when search returns nothing" do
         allow(@query).to receive(:search) # yields nothing
         allow(Chef::Log).to receive(:info) # absorb other log calls
+        allow(Chef::Log).to receive(:debug) # absorb other debug calls
+        expect(Chef::Log).to receive(:debug).with(/op=knife_status status=ok nodes=0 elapsed_ms=\d+/)
         expect(Chef::Log).to receive(:info).with(/op=knife_status status=ok nodes=0 elapsed_ms=\d+/)
         @knife.run
       end
     end
 
-    context "when KNIFE_TIMING is not set (default OFF)" do
+    context "when KNIFE_TIMING is not set (default)" do
       around { |ex| ENV.delete("KNIFE_TIMING"); ex.run }
 
-      it "does not log timing information" do
+      it "always logs timing at debug level" do
         allow(Chef::Log).to receive(:info).with(/Sending query/)
+        expect(Chef::Log).to receive(:debug).with(/op=knife_status status=ok nodes=\d+ elapsed_ms=\d+/)
         expect(Chef::Log).not_to receive(:info).with(/op=knife_status/)
         @knife.run
       end


### PR DESCRIPTION
<h2>Summary</h2>
<p>Promote the <code>knife status</code> timing hook from an undocumented env-var gate to an always-on <code>debug</code>-level log, and add a second instrumentation point in <code>knife node show</code>.</p>

<h2>Problem</h2>
<p>Crawl Ex9 added structured timing in <code>status.rb</code> but gated it behind <code>ENV["KNIFE_TIMING"]</code> — invisible unless you knew the env var existed. No other command had any instrumentation.</p>

<h2>Changes</h2>
<ul>
  <li><code>lib/chef/knife/status.rb</code> — always emit <code>Chef::Log.debug("op=knife_status status=ok nodes=N elapsed_ms=T")</code>; keep <code>info</code>-level log when <code>KNIFE_TIMING</code> set (backward compat)</li>
  <li><code>lib/chef/knife/node_show.rb</code> — wrap <code>Chef::Node.load</code> with <code>CLOCK_MONOTONIC</code>; emit <code>Chef::Log.debug("op=knife_node_show status=ok node=NAME elapsed_ms=T")</code></li>
  <li><code>spec/unit/knife/status_spec.rb</code> — update specs: assert debug emitted unconditionally; info only when KNIFE_TIMING</li>
  <li><code>spec/unit/knife/node_show_spec.rb</code> — new example asserting debug log on run</li>
  <li><code>ai-track-docs/observability.md</code> — append Walk Ex9 verification section</li>
</ul>

<h2>Verification</h2>
<pre>
# knife status timing (always at debug)
knife status --log-level debug 2>&amp;1 | grep op=knife_status
# => DEBUG: op=knife_status status=ok nodes=42 elapsed_ms=123

# knife node show timing (new)
knife node show mynode --log-level debug 2>&amp;1 | grep op=knife_node_show
# => DEBUG: op=knife_node_show status=ok node=mynode elapsed_ms=45
</pre>

<h2>Evidence</h2>
<pre>
bundle exec rspec spec/unit/knife/status_spec.rb spec/unit/knife/node_show_spec.rb
27 examples, 0 failures

bundle exec cookstyle --chefstyle -c .rubocop.yml [4 changed files]
4 files inspected, no offenses detected
</pre>

<h2>Risk</h2>
<p>Low — <code>debug</code> level is off by default; no behavior change at normal log levels. <code>KNIFE_TIMING</code> still works as before.</p>

<h2>Rollback</h2>
<pre>git revert HEAD</pre>

<h2>Track</h2>
<p>Walk Ex9 — Observability Enhancement</p>