### PR TITLE
[DO NOT MERGE] GHCP -- Walk: Ex13 Feature Flags Validated ON/OFF

### DIFF
--- a/.github/workflows/feature-flag-matrix.yml
+++ b/.github/workflows/feature-flag-matrix.yml
@@ -48,8 +48,8 @@ jobs:
 
       - run: bundle install
 
-      - name: Run status specs with KNIFE_TIMING ${{ matrix.label }}
-        run: bundle exec rspec spec/unit/knife/status_spec.rb --format documentation 2>&1 | tee /tmp/flag_output.txt
+      - name: Run status and node_show specs with KNIFE_TIMING ${{ matrix.label }}
+        run: bundle exec rspec spec/unit/knife/status_spec.rb spec/unit/knife/node_show_spec.rb --format documentation 2>&1 | tee /tmp/flag_output.txt
 
       - name: Post flag validation to job summary
         if: always()
@@ -58,15 +58,20 @@ jobs:
           output  = File.read("/tmp/flag_output.txt")
           flag    = ENV["KNIFE_TIMING"].to_s.empty? ? "OFF (unset)" : "ON (#{ENV["KNIFE_TIMING"]})"
           examples = output.match(/(\d+) examples?, (\d+) failures?/)
-          timing_logged = output.include?("logs node count and elapsed time")
+          debug_present = output.include?("always logs timing at debug level") ||
+                          output.include?("logs load-time duration at debug level")
+          info_present  = output.include?("logs structured fields after search completes") ||
+                          output.include?("logs 0 nodes in structured format")
 
           summary = <<~MD
             ## KNIFE_TIMING=#{flag} — Flag Validation
 
             | Check | Result |
             |-------|--------|
-            | Flag state  | `KNIFE_TIMING=#{ENV["KNIFE_TIMING"].to_s.empty? ? "(unset)" : ENV["KNIFE_TIMING"]}` |
-            | Examples    | #{examples ? "#{examples[1]} examples, #{examples[2]} failures" : "n/a"} |
+            | Flag state             | `KNIFE_TIMING=#{ENV["KNIFE_TIMING"].to_s.empty? ? "(unset)" : ENV["KNIFE_TIMING"]}` |
+            | debug timing (always)  | #{debug_present ? "✅ present" : "⚠️ not detected"} |
+            | info timing (flag only)| #{ENV["KNIFE_TIMING"].to_s.empty? ? "➖ off (expected)" : (info_present ? "✅ present" : "⚠️ not detected")} |
+            | Examples               | #{examples ? "#{examples[1]} examples, #{examples[2]} failures" : "n/a"} |
 
             <details><summary>Full spec output</summary>
 

--- a/ai-track-docs/feature-flag.md
+++ b/ai-track-docs/feature-flag.md
@@ -68,3 +68,71 @@ Both jobs post output to `$GITHUB_STEP_SUMMARY`. `continue-on-error: true` ensur
 # To revert the flag and restore always-on timing:
 git revert HEAD
 ```
+
+---
+
+## Walk Ex13 — Feature Flag Lifecycle Update
+
+### What Changed (Walk Ex9)
+
+Walk Ex9 promoted `KNIFE_TIMING` from "gate all timing" to "gate info-level only". The `debug`-level timing log is now **always emitted** regardless of the flag.
+
+| Behavior | Before Walk Ex9 (Crawl) | After Walk Ex9 (Walk) |
+|----------|------------------------|----------------------|
+| `debug` log | Never (hidden behind flag) | **Always** |
+| `info` log | When `KNIFE_TIMING` set | When `KNIFE_TIMING` set |
+
+### Corrected Flag Lifecycle
+
+| Stage | Detail |
+|-------|--------|
+| **Purpose** | Gates the `info`-level structured timing line (for CI/scripting consumers of log output) |
+| **Default state** | **OFF** — only `debug`-level timing is emitted by default |
+| **Enable** | `KNIFE_TIMING=1 knife status` — adds `info`-level line alongside existing `debug` line |
+| **Disable** | Unset: `unset KNIFE_TIMING` — `debug` line still emitted |
+| **Remove when** | When `--log-level info` is the standard operator mode and the extra `info` line is no longer needed for differentiation |
+
+### CI Matrix Update
+
+`.github/workflows/feature-flag-matrix.yml` now:
+- Runs **both** `status_spec.rb` and `node_show_spec.rb` (Walk Ex9 added timing to node_show too)
+- Reports three rows in the summary:
+  - `debug timing (always)` — ✅ present in both ON and OFF jobs
+  - `info timing (flag only)` — ✅ present in ON job, ➖ off in OFF job (expected)
+  - `Examples` — pass count
+
+### ON/OFF Validation Output
+
+**KNIFE_TIMING=1 (ON):**
+
+| Check | Result |
+|-------|--------|
+| debug timing (always)   | ✅ present |
+| info timing (flag only) | ✅ present |
+| Examples                | 30 examples, 0 failures |
+
+**KNIFE_TIMING unset (OFF):**
+
+| Check | Result |
+|-------|--------|
+| debug timing (always)   | ✅ present |
+| info timing (flag only) | ➖ off (expected) |
+| Examples                | 30 examples, 0 failures |
+
+### Local Validation
+
+```bash
+# ON — debug + info both present
+KNIFE_TIMING=1 bundle exec rspec spec/unit/knife/status_spec.rb spec/unit/knife/node_show_spec.rb \
+  --format documentation 2>&1 | grep -E "always logs|logs structured|load-time"
+
+# OFF — only debug present
+bundle exec rspec spec/unit/knife/status_spec.rb spec/unit/knife/node_show_spec.rb \
+  --format documentation 2>&1 | grep -E "always logs|load-time"
+```
+
+### Rollback
+
+```bash
+git revert HEAD  # reverts feature-flag.md and feature-flag-matrix.yml to Crawl Ex13 state
+```


### PR DESCRIPTION
<h2>Summary</h2>
<p>Update the <code>KNIFE_TIMING</code> feature flag lifecycle documentation and CI matrix to reflect the Walk Ex9 behavior change: <code>debug</code>-level timing is now always-on; <code>KNIFE_TIMING</code> only gates the extra <code>info</code>-level line.</p>

<h2>Evidence</h2>
<pre>
# ON (KNIFE_TIMING=1): debug + info both emitted
# OFF (unset): debug always present, info absent (expected)

KNIFE_TIMING=1 bundle exec rspec spec/unit/knife/status_spec.rb spec/unit/knife/node_show_spec.rb
30 examples, 0 failures

bundle exec rspec spec/unit/knife/status_spec.rb spec/unit/knife/node_show_spec.rb
30 examples, 0 failures
</pre>

<h2>Review Focus</h2>
<ul>
  <li><strong><code>feature-flag.md</code></strong> — Verify the corrected lifecycle table accurately describes current <code>status.rb</code> behavior (debug always, info with flag).</li>
  <li><strong><code>feature-flag-matrix.yml</code></strong> — Matrix now runs both <code>status_spec</code> and <code>node_show_spec</code>; summary reports three rows. Confirm logic is correct for ON vs OFF legs.</li>
  <li><strong>No Ruby source changed</strong> — docs and CI workflow only.</li>
</ul>

<h2>Verification Steps</h2>
<pre>
# Verify ON behavior (debug + info)
KNIFE_TIMING=1 bundle exec rspec spec/unit/knife/status_spec.rb --format documentation   2>&amp;1 | grep -E 'always logs|logs structured'

# Verify OFF behavior (debug only)
bundle exec rspec spec/unit/knife/status_spec.rb --format documentation   2>&amp;1 | grep 'always logs timing at debug'
</pre>

<h2>Risk</h2>
<p>None — docs and CI workflow only. No Ruby source changed.</p>

<h2>Rollback</h2>
<pre>git revert HEAD</pre>

<h2>Track</h2>
<p>Walk Ex13 — Feature Flags Validated ON/OFF</p>