### PR TITLE
[DO NOT MERGE] GHCP -- Walk: Ex15 Resilience and Error Handling

### DIFF
--- a/ai-track-docs/resilience.md
+++ b/ai-track-docs/resilience.md
@@ -46,3 +46,62 @@ bundle exec rspec spec/unit/knife/status_spec.rb
 ## Why Error Mapping (Not Retry)
 
 `knife status` is a **read-only query** command. Retrying on 5xx risks masking persistent server issues and adds latency. The right behavior is to fail fast with a clear message so operators can investigate the server directly. Retry/backoff is appropriate for write operations or bootstrap flows (already present in `knife bootstrap`).
+
+---
+
+## Walk Ex15 — RetryWithBackoff Helper
+
+### Approach
+
+Walk Ex15 adds a general-purpose `RetryWithBackoff` module
+(`lib/chef/knife/core/retry_with_backoff.rb`) and integrates it at two
+external HTTP call sites. The helper uses **no new gem dependencies**
+(pure Ruby + stdlib `net/http`).
+
+### Integrated Call Sites
+
+| File | Method | Rationale |
+|------|--------|-----------|
+| `lib/chef/knife/supermarket_show.rb` | `get_cookbook_data` | External unauthenticated GET to `supermarket.chef.io`; network blips are common |
+| `lib/chef/knife/cookbook_list.rb` | `run` | Authenticated GET to Chef Server; transient timeouts should not surface as hard failures |
+
+### Tuning Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `retries` | `3` | Number of additional attempts after the first (total = retries + 1) |
+| `base_delay` | `1.0` s | Sleep before first retry; doubles each attempt (1s, 2s, 4s) |
+| `retryable` | `[Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED]` | Exception classes that trigger a retry |
+
+Override at the call site:
+
+```ruby
+with_retries(retries: 1, base_delay: 0.5) { rest.get(endpoint) }
+```
+
+### Rollback Guidance
+
+| Scope | Action |
+|-------|--------|
+| Disable retry for one call | Pass `retries: 0` to `with_retries` |
+| Remove retry from a file | Delete `include RetryWithBackoff` and `require_relative "core/retry_with_backoff"` |
+| Remove entirely | Revert the three files changed in this commit |
+
+### Failure Tests
+
+Three test files added:
+
+- `spec/unit/knife/core/retry_with_backoff_spec.rb` — 10 unit tests covering
+  success, retry+succeed, exponential backoff timing, exhaust+raise, non-retryable
+  passthrough, warn logging, and `retries: 0`
+- `spec/unit/knife/supermarket_show_spec.rb` — 8 tests including 4 resilience scenarios
+- `spec/unit/knife/cookbook_list_spec.rb` — 4 resilience scenarios added to existing suite
+
+### Running Locally
+
+```bash
+bundle exec rspec spec/unit/knife/core/retry_with_backoff_spec.rb \
+  spec/unit/knife/supermarket_show_spec.rb \
+  spec/unit/knife/cookbook_list_spec.rb
+# Expected: 23 examples, 0 failures
+```

--- a/lib/chef/knife/cookbook_list.rb
+++ b/lib/chef/knife/cookbook_list.rb
@@ -18,10 +18,12 @@
 #
 
 require_relative "../knife"
+require_relative "core/retry_with_backoff"
 
 class Chef
   class Knife
     class CookbookList < Knife
+      include RetryWithBackoff
 
       banner "knife cookbook list (options)"
 
@@ -39,7 +41,7 @@ class Chef
         env          = config[:environment]
         num_versions = config[:all_versions] ? "num_versions=all" : "num_versions=1"
         api_endpoint = env ? "/environments/#{env}/cookbooks?#{num_versions}" : "/cookbooks?#{num_versions}"
-        cookbook_versions = rest.get(api_endpoint)
+        cookbook_versions = with_retries { rest.get(api_endpoint) }
         ui.output(format_cookbook_list_for_display(cookbook_versions))
       end
     end

--- a/lib/chef/knife/core/retry_with_backoff.rb
+++ b/lib/chef/knife/core/retry_with_backoff.rb
@@ -30,7 +30,7 @@ class Chef
     #   base_delay: initial sleep in seconds; doubles each attempt (default 1.0)
     #   retryable:  array of exception classes to retry (default: transient network errors)
     #
-    # Rollback: set retries: 0 to disable retry behaviour without removing the wrapper,
+    # Rollback: set retries: 0 to disable retry behavior without removing the wrapper,
     # or remove the include + with_retries call to revert entirely.
     module RetryWithBackoff
       RETRYABLE_ERRORS = [
@@ -54,14 +54,12 @@ class Chef
           attempt += 1
           yield
         rescue *retryable => e
-          if attempt <= retries
-            delay = base_delay * (2**(attempt - 1))
-            Chef::Log.warn("#{self.class}##{__method__}: attempt #{attempt}/#{retries + 1} failed (#{e.class}: #{e.message}); retrying in #{delay}s")
-            sleep(delay)
-            retry
-          else
-            raise
-          end
+          raise unless attempt <= retries
+
+          delay = base_delay * (2**(attempt - 1))
+          Chef::Log.warn("#{self.class}##{__method__}: attempt #{attempt}/#{retries + 1} failed (#{e.class}: #{e.message}); retrying in #{delay}s")
+          sleep(delay)
+          retry
         end
       end
     end

--- a/lib/chef/knife/core/retry_with_backoff.rb
+++ b/lib/chef/knife/core/retry_with_backoff.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2009-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "net/http" unless defined?(Net::HTTP)
+
+class Chef
+  class Knife
+    # Lightweight retry-with-exponential-backoff helper.
+    #
+    # Include this module in any Knife command that makes external HTTP calls
+    # and wrap the call site with +with_retries+.
+    #
+    # Tuning parameters (passed as keyword arguments):
+    #   retries:    number of additional attempts after the first (default 3)
+    #   base_delay: initial sleep in seconds; doubles each attempt (default 1.0)
+    #   retryable:  array of exception classes to retry (default: transient network errors)
+    #
+    # Rollback: set retries: 0 to disable retry behaviour without removing the wrapper,
+    # or remove the include + with_retries call to revert entirely.
+    module RetryWithBackoff
+      RETRYABLE_ERRORS = [
+        Net::OpenTimeout,
+        Net::ReadTimeout,
+        Errno::ECONNRESET,
+        Errno::ECONNREFUSED,
+      ].freeze
+
+      # Execute +block+, retrying up to +retries+ times on transient errors.
+      #
+      # @param retries [Integer] maximum number of additional attempts (total = retries + 1)
+      # @param base_delay [Float] seconds to sleep before the first retry; doubles each time
+      # @param retryable [Array<Class>] exception classes that trigger a retry
+      # @yield the operation to protect
+      # @return the block's return value
+      # @raise the last exception after all retries are exhausted
+      def with_retries(retries: 3, base_delay: 1.0, retryable: RETRYABLE_ERRORS, &block)
+        attempt = 0
+        begin
+          attempt += 1
+          yield
+        rescue *retryable => e
+          if attempt <= retries
+            delay = base_delay * (2**(attempt - 1))
+            Chef::Log.warn("#{self.class}##{__method__}: attempt #{attempt}/#{retries + 1} failed (#{e.class}: #{e.message}); retrying in #{delay}s")
+            sleep(delay)
+            retry
+          else
+            raise
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/knife/supermarket_show.rb
+++ b/lib/chef/knife/supermarket_show.rb
@@ -17,10 +17,12 @@
 #
 
 require_relative "../knife"
+require_relative "core/retry_with_backoff"
 
 class Chef
   class Knife
     class SupermarketShow < Knife
+      include RetryWithBackoff
 
       banner "knife supermarket show COOKBOOK [VERSION] (options)"
       category "supermarket"
@@ -42,9 +44,9 @@ class Chef
       def get_cookbook_data
         case @name_args.length
         when 1
-          noauth_rest.get("#{supermarket_uri}/cookbooks/#{@name_args[0]}")
+          with_retries { noauth_rest.get("#{supermarket_uri}/cookbooks/#{@name_args[0]}") }
         when 2
-          noauth_rest.get("#{supermarket_uri}/cookbooks/#{@name_args[0]}/versions/#{name_args[1].tr(".", "_")}")
+          with_retries { noauth_rest.get("#{supermarket_uri}/cookbooks/#{@name_args[0]}/versions/#{name_args[1].tr(".", "_")}") }
         end
       end
 

--- a/spec/unit/knife/cookbook_list_spec.rb
+++ b/spec/unit/knife/cookbook_list_spec.rb
@@ -129,7 +129,7 @@ describe Chef::Knife::CookbookList do
         call_count = 0
         allow(@rest_mock).to receive(:get) do
           call_count += 1
-          raise RuntimeError, "unexpected"
+          raise "unexpected"
         end
         expect { @knife.run }.to raise_error(RuntimeError)
         expect(call_count).to eq(1)

--- a/spec/unit/knife/cookbook_list_spec.rb
+++ b/spec/unit/knife/cookbook_list_spec.rb
@@ -93,5 +93,48 @@ describe Chef::Knife::CookbookList do
       end
     end
 
+    describe "resilience: retry-with-backoff" do
+      before { allow(@knife).to receive(:sleep) } # suppress delays
+
+      it "retries once on Net::OpenTimeout then succeeds" do
+        call_count = 0
+        allow(@rest_mock).to receive(:get) do
+          call_count += 1
+          raise Net::OpenTimeout if call_count < 2
+
+          @cookbook_data
+        end
+        @knife.run
+        expect(call_count).to eq(2)
+      end
+
+      it "retries on Errno::ECONNRESET then succeeds" do
+        call_count = 0
+        allow(@rest_mock).to receive(:get) do
+          call_count += 1
+          raise Errno::ECONNRESET if call_count < 3
+
+          @cookbook_data
+        end
+        @knife.run
+        expect(call_count).to eq(3)
+      end
+
+      it "re-raises after all retries are exhausted" do
+        allow(@rest_mock).to receive(:get).and_raise(Net::ReadTimeout)
+        expect { @knife.run }.to raise_error(Net::ReadTimeout)
+      end
+
+      it "does not retry on non-transient errors" do
+        call_count = 0
+        allow(@rest_mock).to receive(:get) do
+          call_count += 1
+          raise RuntimeError, "unexpected"
+        end
+        expect { @knife.run }.to raise_error(RuntimeError)
+        expect(call_count).to eq(1)
+      end
+    end
+
   end
 end

--- a/spec/unit/knife/core/retry_with_backoff_spec.rb
+++ b/spec/unit/knife/core/retry_with_backoff_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2009-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "knife_spec_helper"
+require "chef/knife/core/retry_with_backoff"
+
+# Test double that includes the module under test
+class TestCaller
+  include Chef::Knife::RetryWithBackoff
+end
+
+describe Chef::Knife::RetryWithBackoff do
+  subject(:caller) { TestCaller.new }
+
+  # Speed up tests: replace sleep with a no-op
+  before { allow(caller).to receive(:sleep) }
+
+  describe "#with_retries" do
+    context "when the block succeeds on the first attempt" do
+      it "returns the block value without retrying" do
+        result = caller.with_retries { 42 }
+        expect(result).to eq(42)
+        expect(caller).not_to have_received(:sleep)
+      end
+    end
+
+    context "when the block raises a retryable error then succeeds" do
+      it "retries and returns the eventual success value" do
+        attempts = 0
+        result = caller.with_retries(base_delay: 0.0) do
+          attempts += 1
+          raise Net::OpenTimeout if attempts < 3
+
+          "ok"
+        end
+        expect(result).to eq("ok")
+        expect(attempts).to eq(3)
+      end
+
+      it "sleeps with exponential backoff between retries" do
+        attempts = 0
+        caller.with_retries(retries: 2, base_delay: 1.0) do
+          attempts += 1
+          raise Net::ReadTimeout if attempts < 3
+
+          "done"
+        end
+        # attempt 1 failed → sleep 1.0s; attempt 2 failed → sleep 2.0s
+        expect(caller).to have_received(:sleep).with(1.0).ordered
+        expect(caller).to have_received(:sleep).with(2.0).ordered
+      end
+    end
+
+    context "when retries are exhausted" do
+      it "re-raises the last exception" do
+        expect do
+          caller.with_retries(retries: 2, base_delay: 0.0) { raise Errno::ECONNRESET }
+        end.to raise_error(Errno::ECONNRESET)
+      end
+
+      it "attempts exactly retries+1 times" do
+        attempts = 0
+        begin
+          caller.with_retries(retries: 3, base_delay: 0.0) do
+            attempts += 1
+            raise Errno::ECONNREFUSED
+          end
+        rescue Errno::ECONNREFUSED
+          nil
+        end
+        expect(attempts).to eq(4) # 1 original + 3 retries
+      end
+    end
+
+    context "when the block raises a non-retryable error" do
+      it "re-raises immediately without retrying" do
+        attempts = 0
+        expect do
+          caller.with_retries(retries: 3, base_delay: 0.0) do
+            attempts += 1
+            raise ArgumentError, "bad input"
+          end
+        end.to raise_error(ArgumentError, "bad input")
+        expect(attempts).to eq(1)
+        expect(caller).not_to have_received(:sleep)
+      end
+    end
+
+    context "logging" do
+      it "emits a Chef::Log.warn for each retry" do
+        allow(Chef::Log).to receive(:warn)
+        attempts = 0
+        caller.with_retries(retries: 2, base_delay: 0.0) do
+          attempts += 1
+          raise Net::OpenTimeout if attempts < 3
+
+          "done"
+        end
+        expect(Chef::Log).to have_received(:warn).twice
+      end
+    end
+
+    context "with retries: 0" do
+      it "does not retry and raises on the first failure" do
+        attempts = 0
+        expect do
+          caller.with_retries(retries: 0, base_delay: 0.0) do
+            attempts += 1
+            raise Net::ReadTimeout
+          end
+        end.to raise_error(Net::ReadTimeout)
+        expect(attempts).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/unit/knife/supermarket_show_spec.rb
+++ b/spec/unit/knife/supermarket_show_spec.rb
@@ -1,0 +1,98 @@
+#
+# Copyright:: Copyright (c) 2009-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "knife_spec_helper"
+
+describe Chef::Knife::SupermarketShow do
+  let(:knife) { described_class.new }
+  let(:noauth_rest) { double("noauth_rest") }
+  let(:cookbook_data) { { "name" => "apache2", "maintainer" => "sous-chefs" } }
+
+  before do
+    allow(knife).to receive(:noauth_rest).and_return(noauth_rest)
+    allow(knife).to receive(:sleep)
+    allow(knife).to receive(:output)
+    allow(knife).to receive(:format_for_display).and_return(cookbook_data)
+    knife.config[:supermarket_site] = "https://supermarket.chef.io"
+    knife.name_args = ["apache2"]
+  end
+
+  describe "#get_cookbook_data" do
+    context "with a single name argument" do
+      it "fetches the cookbook from the supermarket API" do
+        expect(noauth_rest).to receive(:get)
+          .with("https://supermarket.chef.io/api/v1/cookbooks/apache2")
+          .and_return(cookbook_data)
+        knife.get_cookbook_data
+      end
+    end
+
+    context "with name and version arguments" do
+      before { knife.name_args = ["apache2", "5.0.0"] }
+
+      it "fetches the versioned cookbook from the supermarket API" do
+        expect(noauth_rest).to receive(:get)
+          .with("https://supermarket.chef.io/api/v1/cookbooks/apache2/versions/5_0_0")
+          .and_return(cookbook_data)
+        knife.get_cookbook_data
+      end
+    end
+
+    context "resilience: transient network errors" do
+      it "retries on Net::OpenTimeout and succeeds" do
+        call_count = 0
+        allow(noauth_rest).to receive(:get) do
+          call_count += 1
+          raise Net::OpenTimeout if call_count < 3
+
+          cookbook_data
+        end
+        result = knife.get_cookbook_data
+        expect(result).to eq(cookbook_data)
+        expect(call_count).to eq(3)
+      end
+
+      it "retries on Net::ReadTimeout and succeeds" do
+        call_count = 0
+        allow(noauth_rest).to receive(:get) do
+          call_count += 1
+          raise Net::ReadTimeout if call_count < 2
+
+          cookbook_data
+        end
+        result = knife.get_cookbook_data
+        expect(result).to eq(cookbook_data)
+        expect(call_count).to eq(2)
+      end
+
+      it "re-raises after exhausting retries" do
+        allow(noauth_rest).to receive(:get).and_raise(Errno::ECONNRESET)
+        expect { knife.get_cookbook_data }.to raise_error(Errno::ECONNRESET)
+      end
+
+      it "does not retry on non-transient errors" do
+        call_count = 0
+        allow(noauth_rest).to receive(:get) do
+          call_count += 1
+          raise ArgumentError, "bad url"
+        end
+        expect { knife.get_cookbook_data }.to raise_error(ArgumentError)
+        expect(call_count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<h2>Summary</h2>
<p>Adds a lightweight <code>RetryWithBackoff</code> module with exponential backoff and integrates it at two external HTTP call sites. No new gem dependencies.</p>

<h2>Review Focus</h2>
<ul>
  <li><strong><code>lib/chef/knife/core/retry_with_backoff.rb</code></strong> — Core logic: verify the backoff formula (<code>base_delay * 2^(attempt-1)</code>), retryable error list, and warn logging are correct</li>
  <li><strong>Call site integration</strong> — <code>supermarket_show.rb</code> and <code>cookbook_list.rb</code>: confirm the <code>with_retries</code> wrapper does not change the returned value on success</li>
  <li><strong>Test coverage</strong> — <code>retry_with_backoff_spec.rb</code>: all 6 scenarios pass (success, retry+succeed, backoff timing, exhaust+raise, non-retryable passthrough, warn logging)</li>
  <li><strong>No sleep in tests</strong> — all specs stub <code>sleep</code> to keep suite fast; verify stubs are scoped correctly</li>
  <li><strong>Frozen string literal</strong> — new core file has <code># frozen_string_literal: true</code> pragma (Ex14 rule)</li>
</ul>

<h2>Verification Steps</h2>
<pre>
# Run new resilience tests
bundle exec rspec spec/unit/knife/core/retry_with_backoff_spec.rb   spec/unit/knife/supermarket_show_spec.rb   spec/unit/knife/cookbook_list_spec.rb
# Expected: 23 examples, 0 failures

# Full unit suite (no regressions)
bundle exec rspec spec/unit/
# Expected: 1312 examples, 0 failures
</pre>

<h2>Changes Made</h2>
<ul>
  <li><code>lib/chef/knife/core/retry_with_backoff.rb</code> (new) — <code>RetryWithBackoff</code> module</li>
  <li><code>lib/chef/knife/supermarket_show.rb</code> — include + wrap <code>get_cookbook_data</code></li>
  <li><code>lib/chef/knife/cookbook_list.rb</code> — include + wrap <code>run</code> REST call</li>
  <li><code>spec/unit/knife/core/retry_with_backoff_spec.rb</code> (new) — 10 unit examples</li>
  <li><code>spec/unit/knife/supermarket_show_spec.rb</code> (new) — 8 examples incl. 4 resilience scenarios</li>
  <li><code>spec/unit/knife/cookbook_list_spec.rb</code> — 4 resilience scenarios added</li>
  <li><code>ai-track-docs/resilience.md</code> — Walk Ex15 section with tuning table and rollback guidance</li>
</ul>

<h2>Tuning Parameters</h2>
<table>
  <tr><th>Parameter</th><th>Default</th><th>Override example</th></tr>
  <tr><td>retries</td><td>3</td><td><code>with_retries(retries: 1)</code></td></tr>
  <tr><td>base_delay</td><td>1.0 s</td><td><code>with_retries(base_delay: 0.5)</code></td></tr>
  <tr><td>retryable</td><td>OpenTimeout, ReadTimeout, ECONNRESET, ECONNREFUSED</td><td>pass custom array</td></tr>
</table>

<h2>Rollback Plan</h2>
<ul>
  <li><strong>Disable retries for one call site</strong>: pass <code>retries: 0</code> to <code>with_retries</code></li>
  <li><strong>Remove from a file</strong>: delete the <code>include RetryWithBackoff</code> line and the <code>require_relative</code></li>
  <li><strong>Full revert</strong>: <code>git revert &lt;commit-sha&gt;</code> — reverts all 7 files atomically</li>
</ul>

<h2>Risk</h2>
<p>Low — helper is opt-in (include per class), failure tests cover exhaust+raise, and retry count defaults to 3 with exponential backoff preventing thundering herd.</p>