### PR TITLE
[DO NOT MERGE] GHCP -- Run: Ex3 Tiny Refactor

### DIFF
--- a/lib/chef/knife/node_run_list_add.rb
+++ b/lib/chef/knife/node_run_list_add.rb
@@ -27,6 +27,9 @@ class Chef
         require "chef/json_compat" unless defined?(Chef::JSONCompat)
       end
 
+      require_relative "node_run_list_base"
+      include Chef::Knife::NodeRunListBase
+
       banner "knife node run_list add [NODE] [ENTRY [ENTRY]] (options)"
 
       option :after,
@@ -41,15 +44,7 @@ class Chef
 
       def run
         node = Chef::Node.load(@name_args[0])
-        if @name_args.size > 2
-          # Check for nested lists and create a single plain one
-          entries = @name_args[1..].map do |entry|
-            entry.split(",").map(&:strip)
-          end.flatten
-        else
-          # Convert to array and remove the extra spaces
-          entries = @name_args[1].split(",").map(&:strip)
-        end
+        entries = parse_run_list_entries(@name_args[1..])
 
         if config[:after] && config[:before]
           ui.fatal("You cannot specify both --before and --after!")

--- a/lib/chef/knife/node_run_list_base.rb
+++ b/lib/chef/knife/node_run_list_base.rb
@@ -1,0 +1,41 @@
+#
+# Author:: Nikhil Gupta
+# Copyright:: Copyright (c) 2009-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../knife"
+
+class Chef
+  class Knife
+    module NodeRunListBase
+
+      private
+
+      # Normalises an array of run-list arguments into a flat list of entries.
+      # Handles both space-separated arguments and comma-separated values within
+      # a single argument, stripping surrounding whitespace from each entry.
+      #
+      # Examples:
+      #   parse_run_list_entries(["role[web]"])            # => ["role[web]"]
+      #   parse_run_list_entries(["role[web],recipe[ntp]"]) # => ["role[web]", "recipe[ntp]"]
+      #   parse_run_list_entries(["role[web]", "recipe[ntp]"]) # => ["role[web]", "recipe[ntp]"]
+      def parse_run_list_entries(args)
+        args.flat_map { |entry| entry.split(",").map(&:strip) }
+      end
+
+    end
+  end
+end

--- a/lib/chef/knife/node_run_list_base.rb
+++ b/lib/chef/knife/node_run_list_base.rb
@@ -24,7 +24,7 @@ class Chef
 
       private
 
-      # Normalises an array of run-list arguments into a flat list of entries.
+      # Normalizes an array of run-list arguments into a flat list of entries.
       # Handles both space-separated arguments and comma-separated values within
       # a single argument, stripping surrounding whitespace from each entry.
       #

--- a/lib/chef/knife/node_run_list_remove.rb
+++ b/lib/chef/knife/node_run_list_remove.rb
@@ -27,20 +27,14 @@ class Chef
         require "chef/json_compat" unless defined?(Chef::JSONCompat)
       end
 
+      require_relative "node_run_list_base"
+      include Chef::Knife::NodeRunListBase
+
       banner "knife node run_list remove [NODE] [ENTRY [ENTRY]] (options)"
 
       def run
         node = Chef::Node.load(@name_args[0])
-
-        if @name_args.size > 2
-          # Check for nested lists and create a single plain one
-          entries = @name_args[1..].map do |entry|
-            entry.split(",").map(&:strip)
-          end.flatten
-        else
-          # Convert to array and remove the extra spaces
-          entries = @name_args[1].split(",").map(&:strip)
-        end
+        entries = parse_run_list_entries(@name_args[1..])
 
         # iterate over the list of things to remove,
         # warning if one of them was not found

--- a/lib/chef/knife/node_run_list_set.rb
+++ b/lib/chef/knife/node_run_list_set.rb
@@ -27,6 +27,9 @@ class Chef
         require "chef/json_compat" unless defined?(Chef::JSONCompat)
       end
 
+      require_relative "node_run_list_base"
+      include Chef::Knife::NodeRunListBase
+
       banner "knife node run_list set NODE ENTRIES (options)"
 
       def run
@@ -34,15 +37,9 @@ class Chef
           ui.fatal "You must supply both a node name and a run list."
           show_usage
           exit 1
-        elsif @name_args.size > 2
-          # Check for nested lists and create a single plain one
-          entries = @name_args[1..].map do |entry|
-            entry.split(",").map(&:strip)
-          end.flatten
-        else
-          # Convert to array and remove the extra spaces
-          entries = @name_args[1].split(",").map(&:strip)
         end
+
+        entries = parse_run_list_entries(@name_args[1..])
         node = Chef::Node.load(@name_args[0])
 
         set_run_list(node, entries)

--- a/spec/unit/knife/node_run_list_base_spec.rb
+++ b/spec/unit/knife/node_run_list_base_spec.rb
@@ -1,0 +1,60 @@
+#
+# Copyright:: Copyright (c) 2009-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "knife_spec_helper"
+
+describe Chef::Knife::NodeRunListBase do
+  # Minimal test double that mixes in the module
+  let(:host) do
+    Class.new do
+      include Chef::Knife::NodeRunListBase
+      public :parse_run_list_entries
+    end.new
+  end
+
+  describe "#parse_run_list_entries" do
+    it "returns a single entry unchanged" do
+      expect(host.parse_run_list_entries(["role[web]"])).to eq(["role[web]"])
+    end
+
+    it "splits a single comma-separated argument into multiple entries" do
+      expect(host.parse_run_list_entries(["role[web],recipe[ntp]"])).to eq(%w{role[web] recipe[ntp]})
+    end
+
+    it "handles multiple space-separated arguments" do
+      expect(host.parse_run_list_entries(["role[web]", "recipe[ntp]"])).to eq(%w{role[web] recipe[ntp]})
+    end
+
+    it "flattens mixed multi-arg and comma-separated values" do
+      result = host.parse_run_list_entries(["role[web]", "recipe[ntp],role[db]"])
+      expect(result).to eq(%w{role[web] recipe[ntp] role[db]})
+    end
+
+    it "strips surrounding whitespace from each entry" do
+      expect(host.parse_run_list_entries(["role[web], recipe[ntp]"])).to eq(%w{role[web] recipe[ntp]})
+    end
+
+    it "returns an empty array for an empty input" do
+      expect(host.parse_run_list_entries([])).to eq([])
+    end
+
+    it "ignores a trailing comma (Ruby split drops trailing empty tokens)" do
+      result = host.parse_run_list_entries(["role[web],"])
+      expect(result).to eq(["role[web]"])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- **What changed**: Extracted duplicated run-list entry parsing into a shared `NodeRunListBase` module
- **Patch plan**: Identified identical 5-line if/else block in 3 commands → extracted to module → replaced all 3 callers → unit-tested the helper directly
- **Files touched**: `lib/chef/knife/node_run_list_base.rb` (new), `node_run_list_add.rb`, `node_run_list_remove.rb`, `node_run_list_set.rb`, `spec/unit/knife/node_run_list_base_spec.rb` (new)

### Refactor: duplicated block removed from 3 files

**Before** (identical 5-line block in each of 3 files):
```ruby
if @name_args.size > 2
  entries = @name_args[1..].map do |entry|
    entry.split(",").map(&:strip)
  end.flatten
else
  entries = @name_args[1].split(",").map(&:strip)
end
```

**After** (one line per caller, behaviour identical):
```ruby
entries = parse_run_list_entries(@name_args[1..])
```

Helper (in `NodeRunListBase`):
```ruby
def parse_run_list_entries(args)
  args.flat_map { |entry| entry.split(",").map(&:strip) }
end
```

---

## Evidence

### Tests
```
bundle exec rspec spec/unit/knife/node_run_list_{base,add,remove,set}_spec.rb
38 examples, 0 failures

Full regression:
bundle exec rspec spec/unit/
1408 examples, 0 failures, 2 pending
```

### Lint
```
bundle exec cookstyle --chefstyle [5 changed files]
5 files inspected, 0 offenses detected
```

### Delegation checklist completed: yes

---

## Risk & Rollback
- **Risk**: Low — pure behaviour-preserving extraction; flat_map is semantically identical to the map+flatten pattern for non-nested enumerables
- **Rollback**: `git revert bd14d4c`
- **Rollback commands**:
```bash
git revert bd14d4c --no-edit
git push origin learn/run/nikhil-ex3-refactor
```

---

## Track
- **Level**: Run
- **Exercise**: Ex3 — Tiny Refactor (behavior-preserving)

---

## Delegation Checklist
- [x] Patch plan created (scope: node_run_list_* subsystem, 4 files)
- [x] File scope defined (node_run_list subsystem only)
- [x] Diffs reviewed before committing
- [x] Tests generated — 7 new examples for NodeRunListBase
- [x] Tests run and passing (38 examples, 0 failures)
- [x] Documentation updated (module has inline doc comments)
- [x] Evidence captured (before/after code, regression output)
- [x] Rollback plan documented
- [x] PR opened with template filled in