### PR TITLE
[DO NOT MERGE] GHCP -- Run: Ex5 API/Contract Hardening

### DIFF
--- a/ai-track-docs/contract-test.md
+++ b/ai-track-docs/contract-test.md
@@ -70,3 +70,70 @@ field is renamed, added, or removed), follow these steps:
 - Renaming an optional field (e.g., `ip` → `ipaddress`)
 
 Breaking changes should be called out in the CHANGELOG and PR description.
+
+---
+
+# Contract Test: GenericPresenter Output Boundaries
+
+## Run Ex5 — API/Contract Hardening
+
+### Contract Surface
+
+**File**: `lib/chef/knife/core/generic_presenter.rb`  
+**Consumers**: All 149 knife subcommands via `format_for_display` and `format_list_for_display`
+
+`GenericPresenter` is the highest-fan-out boundary in the codebase. Changing any
+public method here affects every `knife * show` and `knife * list` command.
+
+---
+
+### Boundary A — `format_list_for_display(list)`
+
+| Config | Return shape | Notes |
+|--------|-------------|-------|
+| Default (no flags) | `Array<String>` — keys sorted A–Z | Stable alphabetical order required by scripts |
+| `config[:with_uri] = true` | Original `Hash` unchanged | Scripts use URI values directly |
+| Empty input | `[]` (not nil) | Callers do not guard against nil |
+
+**Spec location**: `spec/unit/knife/core/generic_presenter_spec.rb` — `contract: format_list_for_display`
+
+---
+
+### Boundary B — `format_for_display(data)`
+
+| Config flag | Return shape | Rationale |
+|-------------|-------------|-----------|
+| None | `data` unchanged (passthrough) | Zero-cost default; ui.output formats it |
+| `config[:id_only]` | Bare String (name or id) | Scripted enumeration — not a Hash |
+| `config[:environment]` | `{"chef_environment" => String}` | Key name is stable; scripts parse it |
+| `config[:attribute]` | `{name => {attr => value}}` | Subset extraction; stable nesting shape |
+| `config[:run_list]` | `{name => {"run_list" => Array}}` | Key name `"run_list"` must not change |
+
+**Spec location**: `spec/unit/knife/core/generic_presenter_spec.rb` — `contract: format_for_display`
+
+---
+
+### Boundary C — `format_data_subset_for_display` / `extract_nested_value`
+
+- Calling `format_for_display` with `config[:attribute]` or `config[:run_list]` set (but nil values) raises `ArgumentError` — **this is intentional**: silent nil would produce empty output with no diagnostic.
+- Dot-separated attribute paths (e.g. `"automatic.platform"`) return nil on missing intermediate keys — no exception raised.
+- Array elements are accessed via numeric string index (e.g. `"arr.0"`).
+
+---
+
+### Updating the GenericPresenter Contract
+
+1. Make the code change in `lib/chef/knife/core/generic_presenter.rb`
+2. Run: `bundle exec rspec spec/unit/knife/core/generic_presenter_spec.rb`
+3. If a contract test fails, confirm the change is intentional
+4. Update the failing example to match the new behaviour
+5. Update the relevant table above (Boundary A, B, or C)
+6. Add a **"Contract Change"** section to the PR description
+
+### What Counts as a Breaking Change
+
+- Changing the return type of any method in Boundaries A or B
+- Renaming a hash key in the return value (e.g., `"run_list"` → `"runList"`)
+- Changing `extract_nested_value` to raise instead of returning nil on missing paths
+
+Breaking changes must be called out in the PR description and CHANGELOG.

--- a/ai-track-docs/contract-test.md
+++ b/ai-track-docs/contract-test.md
@@ -126,7 +126,7 @@ public method here affects every `knife * show` and `knife * list` command.
 1. Make the code change in `lib/chef/knife/core/generic_presenter.rb`
 2. Run: `bundle exec rspec spec/unit/knife/core/generic_presenter_spec.rb`
 3. If a contract test fails, confirm the change is intentional
-4. Update the failing example to match the new behaviour
+4. Update the failing example to match the new behavior
 5. Update the relevant table above (Boundary A, B, or C)
 6. Add a **"Contract Change"** section to the PR description
 

--- a/spec/unit/knife/core/generic_presenter_spec.rb
+++ b/spec/unit/knife/core/generic_presenter_spec.rb
@@ -1,0 +1,200 @@
+#
+# Copyright:: Copyright (c) 2009-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "knife_spec_helper"
+
+# Contract tests for Chef::Knife::Core::GenericPresenter
+#
+# These tests define the stable output contracts for the two most-used methods:
+#   - format_list_for_display  (used by all knife *_list commands)
+#   - format_for_display       (used by all knife *_show commands)
+#
+# If you intentionally change a contract, update the relevant example AND add a
+# "Contract Change" section to the PR description. See ai-track-docs/contract-test.md.
+#
+# Rationale for each boundary tested is documented inline.
+describe Chef::Knife::Core::GenericPresenter do
+  let(:ui)        { double("UI") }
+  let(:config)    { {} }
+  let(:presenter) { described_class.new(ui, config) }
+
+  # =========================================================================
+  # Boundary A — format_list_for_display
+  #
+  # Contract: consumers of knife *_list commands expect a sorted array of
+  # string keys by default. Passing --with-uri returns the original hash so
+  # scripts can access URIs without a second API call.
+  # =========================================================================
+  describe "contract: format_list_for_display" do
+    let(:sample_list) { { "zebra" => "http://z", "apple" => "http://a", "mango" => "http://m" } }
+
+    context "default (no --with-uri)" do
+      it "returns an array of keys sorted alphabetically" do
+        # Rationale: all knife *_list commands pipe this into ui.output; scripts
+        # that parse the output rely on alphabetical ordering being stable.
+        expect(presenter.format_list_for_display(sample_list)).to eq(%w{apple mango zebra})
+      end
+
+      it "returns an empty array for an empty list" do
+        # Rationale: no-data case must not raise — callers do not guard against nil.
+        expect(presenter.format_list_for_display({})).to eq([])
+      end
+    end
+
+    context "with config[:with_uri] = true" do
+      let(:config) { { with_uri: true } }
+
+      it "returns the raw hash unchanged" do
+        # Rationale: scripts using --with-uri need the URI values; the hash
+        # must not be transformed or sorted.
+        expect(presenter.format_list_for_display(sample_list)).to eq(sample_list)
+      end
+    end
+  end
+
+  # =========================================================================
+  # Boundary B — format_for_display
+  #
+  # Contract: the output shape depends on the combination of config flags.
+  # Each branch is tested independently so any flag interaction regression
+  # is immediately visible.
+  # =========================================================================
+  describe "contract: format_for_display" do
+    let(:node_double) do
+      double("node",
+        name: "test-node",
+        chef_environment: "production",
+        run_list: double("run_list", run_list: ["role[web]"])
+      )
+    end
+
+    context "no flags set (passthrough)" do
+      it "returns the data object unchanged" do
+        # Rationale: the default path must be zero-cost; callers pass the raw
+        # API object and expect it back so ui.output can format it.
+        data = { "id" => "x", "value" => 42 }
+        expect(presenter.format_for_display(data)).to eq(data)
+      end
+    end
+
+    context "config[:id_only] = true" do
+      let(:config) { { id_only: true } }
+
+      it "returns the name of an object that responds to :name" do
+        # Rationale: --id-only mode is used for scripted enumeration;
+        # consumers get a bare string, not a hash.
+        expect(presenter.format_for_display(node_double)).to eq("test-node")
+      end
+
+      it "returns data['id'] for plain hashes" do
+        data = { "id" => "hash-id", "extra" => "ignored" }
+        expect(presenter.format_for_display(data)).to eq("hash-id")
+      end
+    end
+
+    context "config[:environment] = true with an object that has chef_environment" do
+      let(:config) { { environment: true } }
+
+      it "returns {\"chef_environment\" => value}" do
+        # Rationale: --environment flag filters output to just the env field;
+        # the key name is part of the stable API contract (scripts parse it).
+        expect(presenter.format_for_display(node_double)).to eq({ "chef_environment" => "production" })
+      end
+    end
+
+    context "config[:attribute] set (subset extraction)" do
+      let(:node_with_attrs) do
+        double("node",
+          name: "attr-node",
+          respond_to?: true,
+          public_send: nil
+        ).tap do |n|
+          allow(n).to receive(:respond_to?).with(:name).and_return(true)
+          allow(n).to receive(:name).and_return("attr-node")
+          allow(n).to receive(:respond_to?).with(:[], false).and_return(true)
+          allow(n).to receive(:respond_to?).with(:key?).and_return(true)
+          allow(n).to receive(:key?).with("platform").and_return(true)
+          allow(n).to receive(:[]).with("platform").and_return("ubuntu")
+          allow(n).to receive(:respond_to?).with(:to_hash).and_return(false)
+        end
+      end
+
+      it "returns {name => {attr => value}} subset" do
+        # Rationale: --attribute flag is used for scripted extraction of a
+        # single field; the returned shape {name => {attr => val}} is stable.
+        config[:attribute] = ["platform"]
+        result = presenter.format_for_display(node_with_attrs)
+        expect(result).to eq({ "attr-node" => { "platform" => "ubuntu" } })
+      end
+    end
+
+    context "config[:run_list] set" do
+      let(:config) { { run_list: true } }
+
+      it "returns {name => {\"run_list\" => [...]}} subset" do
+        # Rationale: --run-list flag has a stable output shape used by automation
+        # that reads run lists programmatically.
+        result = presenter.format_for_display(node_double)
+        expect(result).to eq({ "test-node" => { "run_list" => ["role[web]"] } })
+      end
+    end
+  end
+
+  # =========================================================================
+  # Boundary C — format_data_subset_for_display edge cases
+  #
+  # Rationale: the method raises ArgumentError when called with no valid flag.
+  # This is an explicit contract — callers must set at least one of :attribute,
+  # :run_list, or :id_only before calling format_for_display with complex data.
+  # =========================================================================
+  describe "contract: format_data_subset_for_display raises on bad config" do
+    let(:config) { { attribute: nil, run_list: nil } }
+
+    it "raises ArgumentError when neither :attribute nor :run_list is set" do
+      # Rationale: silent nil returns here would produce empty output with no
+      # error, which is harder to diagnose than a clear ArgumentError.
+      data = double("data", name: "n", respond_to?: true)
+      allow(data).to receive(:respond_to?).with(:name).and_return(true)
+      allow(data).to receive(:name).and_return("n")
+      expect { presenter.send(:format_data_subset_for_display, data) }
+        .to raise_error(ArgumentError, /requires attribute, run_list, or id_only/)
+    end
+  end
+
+  # =========================================================================
+  # Boundary D — extract_nested_value edge cases
+  #
+  # Rationale: dot-separated attribute paths are parsed at runtime; a nil
+  # intermediate value must return nil (not raise NoMethodError).
+  # =========================================================================
+  describe "contract: extract_nested_value" do
+    let(:data) { { "a" => { "b" => "deep" }, "arr" => ["zero", "one"] } }
+
+    it "returns a deeply nested value for a dot-separated path" do
+      expect(presenter.send(:extract_nested_value, data, "a.b")).to eq("deep")
+    end
+
+    it "returns nil when an intermediate key is missing" do
+      # Rationale: users typo attribute paths; nil return is preferable to crash.
+      expect(presenter.send(:extract_nested_value, data, "a.missing.leaf")).to be_nil
+    end
+
+    it "returns the element at a numeric index for arrays" do
+      expect(presenter.send(:extract_nested_value, data, "arr.1")).to eq("one")
+    end
+  end
+end

--- a/spec/unit/knife/core/generic_presenter_spec.rb
+++ b/spec/unit/knife/core/generic_presenter_spec.rb
@@ -78,8 +78,7 @@ describe Chef::Knife::Core::GenericPresenter do
       double("node",
         name: "test-node",
         chef_environment: "production",
-        run_list: double("run_list", run_list: ["role[web]"])
-      )
+        run_list: double("run_list", run_list: ["role[web]"]))
     end
 
     context "no flags set (passthrough)" do
@@ -118,19 +117,15 @@ describe Chef::Knife::Core::GenericPresenter do
 
     context "config[:attribute] set (subset extraction)" do
       let(:node_with_attrs) do
-        double("node",
-          name: "attr-node",
-          respond_to?: true,
-          public_send: nil
-        ).tap do |n|
-          allow(n).to receive(:respond_to?).with(:name).and_return(true)
-          allow(n).to receive(:name).and_return("attr-node")
-          allow(n).to receive(:respond_to?).with(:[], false).and_return(true)
-          allow(n).to receive(:respond_to?).with(:key?).and_return(true)
-          allow(n).to receive(:key?).with("platform").and_return(true)
-          allow(n).to receive(:[]).with("platform").and_return("ubuntu")
-          allow(n).to receive(:respond_to?).with(:to_hash).and_return(false)
-        end
+        n = double("node")
+        allow(n).to receive(:respond_to?).with(:name).and_return(true)
+        allow(n).to receive(:name).and_return("attr-node")
+        allow(n).to receive(:respond_to?).with(:[], false).and_return(true)
+        allow(n).to receive(:respond_to?).with(:key?).and_return(true)
+        allow(n).to receive(:key?).with("platform").and_return(true)
+        allow(n).to receive(:[]).with("platform").and_return("ubuntu")
+        allow(n).to receive(:respond_to?).with(:to_hash).and_return(false)
+        n
       end
 
       it "returns {name => {attr => value}} subset" do
@@ -182,7 +177,7 @@ describe Chef::Knife::Core::GenericPresenter do
   # intermediate value must return nil (not raise NoMethodError).
   # =========================================================================
   describe "contract: extract_nested_value" do
-    let(:data) { { "a" => { "b" => "deep" }, "arr" => ["zero", "one"] } }
+    let(:data) { { "a" => { "b" => "deep" }, "arr" => %w{zero one} } }
 
     it "returns a deeply nested value for a dot-separated path" do
       expect(presenter.send(:extract_nested_value, data, "a.b")).to eq("deep")


### PR DESCRIPTION
## Summary
- **What changed**: Added contract tests for `GenericPresenter` — the highest-fan-out boundary (all 149 subcommands use it); updated contract-test.md with boundary tables and update guidance
- **Patch plan**: Audit → find no `generic_presenter_spec.rb` → identify 4 untested boundaries → write 13 deterministic contract tests → document update process
- **Files touched**: `spec/unit/knife/core/generic_presenter_spec.rb` (new), `ai-track-docs/contract-test.md`

### Audit Findings (TODOs / edge cases)

| Finding | Location | Risk |
|---------|----------|------|
| No spec file for `GenericPresenter` | `spec/unit/knife/core/` | Any silent regression in format_for_display affects all 149 commands |
| `format_for_display` — 4 paths, 0 tests | `generic_presenter.rb:147` | Passthrough, id_only, environment, attribute/run_list all untested |
| `format_list_for_display` — 2 paths, 0 tests | `generic_presenter.rb:143` | Sort order relied on by scripts, never asserted |
| `format_data_subset_for_display` raises `ArgumentError` | `generic_presenter.rb:171` | Silent nil return could mask misconfiguration; raise is the contract |
| `extract_nested_value` nil path | `generic_presenter.rb:191` | Nil intermediate key must return nil, not raise |

### Contract tests added (13 examples)

| Boundary | Examples | Rationale |
|----------|----------|-----------|
| A: `format_list_for_display` | 3 | Sorted keys, empty list, with_uri passthrough |
| B: `format_for_display` | 6 | Passthrough, id_only (name + hash), environment, attribute subset, run_list |
| C: `ArgumentError` guard | 1 | Explicit contract: no silent nil on bad config |
| D: `extract_nested_value` | 3 | Nested dot path, nil on missing key, array index |

---

## Evidence

```
bundle exec rspec spec/unit/knife/core/generic_presenter_spec.rb
13 examples, 0 failures

Full regression:
bundle exec rspec spec/unit/
1421 examples, 0 failures, 2 pending
```

### Delegation checklist completed: yes

---

## Risk & Rollback
- **Risk**: Low — spec-only addition; no production code changed
- **Rollback**: `git revert 7cbfc04`
- **Rollback commands**:
```bash
git revert 7cbfc04 --no-edit
git push origin learn/run/nikhil-ex5-contract
```

---

## What is a Contract Test?
A contract test asserts the *shape* of an output boundary — not just that a method returns *something*, but that it returns the exact structure consumers depend on. If the return type, key name, or sort order changes, the contract test fails immediately and the PR author must confirm the change is intentional. This turns accidental regressions into explicit decisions.

---

## Track
- **Level**: Run
- **Exercise**: Ex5 — API/Contract Hardening

---

## Delegation Checklist
- [x] Patch plan created (audit → 4 untested boundaries → 2 files)
- [x] File scope defined (core/generic_presenter subsystem only)
- [x] Diffs reviewed before committing
- [x] Tests generated — 13 examples with inline rationale
- [x] Tests run and passing (13/13)
- [x] Documentation updated (contract-test.md GenericPresenter section)
- [x] Evidence captured (audit table + test output)
- [x] Rollback plan documented
- [x] PR opened with template filled in