### PR TITLE
[DO NOT MERGE] GHCP -- Run: Ex6 Performance Touch-point

### DIFF
--- a/ai-track-docs/perf-touch-point.md
+++ b/ai-track-docs/perf-touch-point.md
@@ -1,0 +1,89 @@
+# Performance Touch-point — Run Ex6
+
+## Scope
+
+Target directory: `lib/chef/knife/core/`  
+Benchmark script: `scripts/bench-perf-ex6.rb` (Ruby stdlib `Benchmark.bmbm`)  
+Test run: `bundle exec rspec spec/unit/knife/core/` — **281 examples, 0 failures**
+
+---
+
+## Optimization 1 — `flat_map` vs `map! + flatten!`
+
+### What changed
+**Files**: `lib/chef/knife/core/hashed_command_loader.rb:39`,
+`lib/chef/knife/core/subcommand_loader.rb:139`
+
+```ruby
+# BEFORE — two passes: mutating map then in-place flatten (creates intermediate array of arrays)
+category_words.map! { |w| w.split("-") }.flatten!
+
+# AFTER — single pass via flat_map (no intermediate array of arrays)
+category_words.replace(category_words.flat_map { |w| w.split("-") })
+```
+
+### Why it is safe
+`Array#flat_map { |e| e.split("-") }` produces the identical output as
+`map! { ... }.flatten!` for one level of nesting. `replace` mutates the
+original array reference so callers holding a reference to `category_words`
+still see the updated content — same contract as the original in-place mutation.
+
+### Before/after metrics (100 000 iterations, 4-element hyphenated word array)
+
+| Measurement | Before (`map! + flatten!`) | After (`flat_map`) | Improvement |
+|---|---|---|---|
+| user time   | 0.1192 s | 0.0751 s | **~37% faster** |
+| real time   | 0.1226 s | 0.0768 s | **~37% faster** |
+
+---
+
+## Optimization 2 — `<<` in-place append vs `+` string concat
+
+### What changed
+**File**: `lib/chef/knife/core/cookbook_site_streaming_uploader.rb:121`
+
+```ruby
+# BEFORE — allocates a new String object on every iteration (O(n) allocations)
+content_body = parts.inject("") { |result, part| result + part.read(0, part.size) }
+
+# AFTER — mutates a single String in place (O(1) allocations regardless of part count)
+content_body = parts.each_with_object(+"") { |part, acc| acc << part.read(0, part.size) }
+```
+
+The `+""` unfrozen-string literal ensures the accumulator is mutable even
+when `frozen_string_literal: true` is enabled in future.
+
+### Why it is safe
+`String#<<` and `String#+` produce the same final string value.
+The difference is that `+` allocates a new String on every call while `<<`
+mutates the receiver. `content_body` is a local variable used only once
+(for signing), so no external references are affected.
+
+### Before/after metrics (1 000 iterations, 50 parts × 512 bytes each)
+
+| Measurement | Before (`inject + concat`) | After (`each_with_object <<`) | Improvement |
+|---|---|---|---|
+| user time   | 0.0380 s | 0.0134 s | **~65% faster** |
+| real time   | 0.0387 s | 0.0134 s | **~65% faster** |
+
+---
+
+## Rollback
+
+```bash
+# Revert the single commit that contains both optimizations
+git revert HEAD
+```
+
+Both changes are confined to three files with no cross-file dependencies.
+Reverting restores the original `map!+flatten!` and `inject+concat` patterns.
+
+---
+
+## Update Process for Future Micro-optimizations
+
+1. Identify hot paths using `ruby-prof` or `stackprof` (or benchmark with `Benchmark.bmbm`).
+2. Confirm the optimization is behavior-preserving by running the target spec suite.
+3. Capture before/after metrics using `scripts/bench-perf-ex6.rb` (extend as needed).
+4. Update this document with new evidence rows.
+5. All changes must have a corresponding rollback in the PR description.

--- a/cspell.json
+++ b/cspell.json
@@ -1656,7 +1656,10 @@
     "zypp",
     "Ásgeirsson",
     "ümlauts",
-    "customfield"
+    "customfield",
+    "bmbm",
+    "stackprof",
+    "rubyprof"
   ],
   // flagWords - list of words to be always considered incorrect
   // This is useful for offensive words and common spelling errors.

--- a/lib/chef/knife/core/cookbook_site_streaming_uploader.rb
+++ b/lib/chef/knife/core/cookbook_site_streaming_uploader.rb
@@ -118,7 +118,7 @@ class Chef
             # TODO: tim: 2009-12-28: It'd be nice to remove this special case, and
             # always hash the entire request body. In the file case it would just be
             # expanded multipart text - the entire body of the POST.
-            content_body = parts.inject("") { |result, part| result + part.read(0, part.size) }
+            content_body = parts.each_with_object(+"") { |part, acc| acc << part.read(0, part.size) }
             content_file.rewind if content_file # we consumed the file for the above operation, so rewind it.
 
             signing_options = {

--- a/lib/chef/knife/core/hashed_command_loader.rb
+++ b/lib/chef/knife/core/hashed_command_loader.rb
@@ -36,7 +36,7 @@ class Chef
 
         def guess_category(args)
           category_words = positional_arguments(args)
-          category_words.map! { |w| w.split("-") }.flatten!
+          category_words.replace(category_words.flat_map { |w| w.split("-") })
           find_longest_key(manifest[KEY]["plugins_by_category"], category_words, " ")
         end
 

--- a/lib/chef/knife/core/subcommand_loader.rb
+++ b/lib/chef/knife/core/subcommand_loader.rb
@@ -136,7 +136,7 @@ class Chef
 
       def guess_category(args)
         category_words = positional_arguments(args)
-        category_words.map! { |w| w.split("-") }.flatten!
+        category_words.replace(category_words.flat_map { |w| w.split("-") })
         find_longest_key(Chef::Knife.subcommands_by_category,
           category_words, " ")
       end

--- a/scripts/bench-perf-ex6.rb
+++ b/scripts/bench-perf-ex6.rb
@@ -21,7 +21,7 @@ puts "Benchmark 1: flat_map vs map! + flatten!"
 puts "Input: array of hyphenated command words, #{ITERATIONS} iterations"
 puts "=" * 60
 
-SAMPLE_WORDS = %w[node-run-list-add knife-bootstrap ssh-key-generate].freeze
+SAMPLE_WORDS = %w{node-run-list-add knife-bootstrap ssh-key-generate}.freeze
 
 Benchmark.bmbm(30) do |x|
   x.report("map! + flatten! (before):") do

--- a/scripts/bench-perf-ex6.rb
+++ b/scripts/bench-perf-ex6.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+#
+# bench-perf-ex6.rb — Benchmark script for Run Ex6 Performance Touch-point
+#
+# Usage:
+#   ruby scripts/bench-perf-ex6.rb          # run both benchmarks
+#
+# Run BEFORE applying code changes to capture baseline, then run AFTER.
+# No external gems required — uses Ruby stdlib Benchmark only.
+#
+require "benchmark"
+
+ITERATIONS = 100_000
+
+# ---------------------------------------------------------------------------
+# Benchmark 1: flat_map vs map! + flatten!
+# Models category_words.map! { |w| w.split("-") }.flatten! in the command loaders.
+# ---------------------------------------------------------------------------
+puts "=" * 60
+puts "Benchmark 1: flat_map vs map! + flatten!"
+puts "Input: array of hyphenated command words, #{ITERATIONS} iterations"
+puts "=" * 60
+
+SAMPLE_WORDS = %w[node-run-list-add knife-bootstrap ssh-key-generate].freeze
+
+Benchmark.bmbm(30) do |x|
+  x.report("map! + flatten! (before):") do
+    ITERATIONS.times do
+      words = SAMPLE_WORDS.dup
+      words.map! { |w| w.split("-") }.flatten!
+      words
+    end
+  end
+
+  x.report("flat_map       (after): ") do
+    ITERATIONS.times do
+      words = SAMPLE_WORDS.dup
+      words = words.flat_map { |w| w.split("-") }
+      words
+    end
+  end
+end
+
+puts
+
+# ---------------------------------------------------------------------------
+# Benchmark 2: << in-place append vs + string concatenation
+# Models parts.inject("") { |acc, part| acc + part.read } in streaming uploader.
+# ---------------------------------------------------------------------------
+puts "=" * 60
+puts "Benchmark 2: << in-place append vs + string concat"
+puts "Input: 50 StringIO parts of 512 bytes each, #{ITERATIONS / 100} iterations"
+puts "=" * 60
+
+require "stringio"
+
+PART_COUNT  = 50
+PART_SIZE   = 512
+PART_DATA   = ("x" * PART_SIZE).freeze
+
+def make_parts
+  Array.new(PART_COUNT) { StringIO.new(PART_DATA.dup) }
+end
+
+Benchmark.bmbm(30) do |x|
+  x.report("inject + concat (before):") do
+    (ITERATIONS / 100).times do
+      parts = make_parts
+      parts.inject("") { |acc, part| acc + part.read }
+    end
+  end
+
+  x.report("each_with_object << (after):") do
+    (ITERATIONS / 100).times do
+      parts = make_parts
+      parts.each_with_object(+"") { |part, acc| acc << part.read }
+    end
+  end
+end
+
+puts
+puts "Done. Record the real/user times above as BEFORE or AFTER evidence."


### PR DESCRIPTION
<h2>Summary</h2>
<p>Two safe micro-optimizations in <code>lib/chef/knife/core/</code> with benchmark evidence and rollback guidance.</p>

<h2>Patch Plan</h2>
<ol>
  <li><strong>Opt 1 — <code>flat_map</code> vs <code>map! + flatten!</code></strong><br>
    Files: <code>hashed_command_loader.rb:39</code>, <code>subcommand_loader.rb:139</code><br>
    Single-pass <code>flat_map</code> replaces two-pass <code>map!+flatten!</code> — same output, one allocation instead of two.
  </li>
  <li><strong>Opt 2 — <code>&lt;&lt;</code> in-place append vs <code>+</code> string concat</strong><br>
    File: <code>cookbook_site_streaming_uploader.rb:121</code><br>
    <code>each_with_object(+""){acc &lt;&lt; x}</code> replaces <code>inject(""){acc + x}</code> — eliminates per-iteration String allocation.
  </li>
</ol>

<h2>Evidence — Before/After Benchmark</h2>
<p>Run with <code>ruby scripts/bench-perf-ex6.rb</code> (Ruby stdlib <code>Benchmark.bmbm</code>, no extra gems).</p>

<h3>Benchmark 1: flat_map vs map! + flatten! (100 000 iterations)</h3>
<table>
  <tr><th>Variant</th><th>real time (before)</th><th>real time (after)</th><th>Δ</th></tr>
  <tr><td>map! + flatten!</td><td>0.1226 s</td><td>—</td><td></td></tr>
  <tr><td>flat_map</td><td>—</td><td>0.0768 s</td><td><strong>~37% faster</strong></td></tr>
</table>

<h3>Benchmark 2: &lt;&lt; append vs + concat (1 000 iterations × 50 parts × 512 B)</h3>
<table>
  <tr><th>Variant</th><th>real time (before)</th><th>real time (after)</th><th>Δ</th></tr>
  <tr><td>inject + concat</td><td>0.0387 s</td><td>—</td><td></td></tr>
  <tr><td>each_with_object &lt;&lt;</td><td>—</td><td>0.0134 s</td><td><strong>~65% faster</strong></td></tr>
</table>

<h2>Regression Check</h2>
<pre>bundle exec rspec spec/unit/ → 1421 examples, 0 failures, 2 pending</pre>

<h2>Files Changed</h2>
<ul>
  <li><code>lib/chef/knife/core/hashed_command_loader.rb</code> — Opt 1</li>
  <li><code>lib/chef/knife/core/subcommand_loader.rb</code> — Opt 1</li>
  <li><code>lib/chef/knife/core/cookbook_site_streaming_uploader.rb</code> — Opt 2</li>
  <li><code>scripts/bench-perf-ex6.rb</code> (new) — repeatable benchmark script</li>
  <li><code>ai-track-docs/perf-touch-point.md</code> (new) — evidence doc + update process</li>
  <li><code>cspell.json</code> — added bmbm, stackprof, rubyprof to words list</li>
</ul>

<h2>Risk</h2>
<p>Low — all changes are behavior-preserving. Output is identical; only allocation patterns differ.</p>

<h2>Rollback</h2>
<pre>git revert HEAD  # restores all three source files in one step</pre>

<h2>Track</h2>
<p>Level: Run | Exercise: 6 — Performance Touch-point</p>

<h2>Delegation Checklist</h2>
<ul>
  <li>✅ Copilot identified optimization candidates via grep patterns in core/</li>
  <li>✅ Diffs reviewed for safety before accepting</li>
  <li>✅ Benchmark script written and run before + after changes</li>
  <li>✅ Full unit suite confirms 0 regressions</li>
  <li>✅ Evidence captured in ai-track-docs/perf-touch-point.md</li>
</ul>