### PR TITLE
[DO NOT MERGE] GHCP -- Run: Ex8 Security and Secrets

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,3 +62,33 @@ The CI job scans full history (thorough). Together they provide:
 |-------|------|-------|
 | Pre-commit hook | `git commit` | Staged diff |
 | CI secret-scan job | PR / push to main | Full git history |
+
+## Secure File Creation
+
+Any code that writes private keys, PEM blobs, or other credential material to disk **must**
+use mode `0600` to restrict access to the file owner only:
+
+```ruby
+# Required pattern for credential files
+File.open(path, "w", 0600) do |f|
+  f.print(private_key_content)
+end
+```
+
+Using the default `"w"` mode (without an explicit octal) inherits the process umask, which
+on most Linux systems yields `0644` (world-readable). All knife commands that write key
+material have been updated to use `0600` explicitly (see `ai-track-docs/security-hygiene.md`).
+
+## Shell Command Safety
+
+Prefer the **array form** of `exec`, `system`, and `Open3.popen*` over string interpolation.
+String form invokes `/bin/sh -c`, making shell metacharacters significant:
+
+```ruby
+# Unsafe — shell processes the string
+exec("cssh #{user}@#{host}")
+
+# Safe — argv passed directly to OS, no shell involved
+exec("cssh", "#{user}@#{host}")
+exec(*["cssh", "#{user}@#{host}"])
+```

--- a/ai-track-docs/security-hygiene.md
+++ b/ai-track-docs/security-hygiene.md
@@ -1,0 +1,107 @@
+# Security Hygiene — Run Ex8
+
+## Scan Methodology
+
+Manual review of `lib/chef/knife/` focused on three common classes:
+1. File creation permissions for sensitive material
+2. Shell injection via `exec()` with string arguments
+3. No secrets scanner needed — `gitleaks` CI job (Walk Ex8) already covers secret detection
+
+---
+
+## Finding 1 — Private key / PEM files created without restricted permissions
+
+### Risk
+`File.open(path, "w")` creates a file with permissions derived from the process umask.
+On a default Linux system (umask `022`) this yields mode `0644` — **world-readable**.
+A private key or PEM file at `0644` can be read by any local user on the same machine.
+
+### Affected files (8)
+
+| File | Writes |
+|------|--------|
+| `lib/chef/knife/key_create.rb:67` | Actor private key |
+| `lib/chef/knife/key_edit.rb:69` | Actor private key |
+| `lib/chef/knife/org_create.rb:53` | Org private key |
+| `lib/chef/knife/user_create.rb:156` | User private key |
+| `lib/chef/knife/user_reregister.rb:50` | User private key |
+| `lib/chef/knife/client_reregister.rb:49` | Client private key |
+| `lib/chef/knife/client_create.rb:97` | Client private key |
+| `lib/chef/knife/configure_client.rb:41` | `validation.pem` |
+
+### Fix
+```ruby
+# BEFORE
+File.open(path, "w") { |f| f.print(key) }
+
+# AFTER
+File.open(path, "w", 0600) { |f| f.print(key) }
+```
+`0600` = owner read/write only. Applies at file creation time regardless of umask.
+
+### Scripted verification
+```bash
+# After knife key create --file /tmp/test.pem ...
+stat -c "%a" /tmp/test.pem  # should print 600
+```
+
+### Rollback
+```bash
+git revert HEAD -- lib/chef/knife/key_create.rb \
+  lib/chef/knife/key_edit.rb lib/chef/knife/org_create.rb \
+  lib/chef/knife/user_create.rb lib/chef/knife/user_reregister.rb \
+  lib/chef/knife/client_reregister.rb lib/chef/knife/client_create.rb \
+  lib/chef/knife/configure_client.rb
+```
+
+---
+
+## Finding 2 — `exec(cssh_cmd)` shell-string injection (ssh.rb:575)
+
+### Risk
+`cssh_cmd` is built from `server.user` and `server.host` via string concatenation,
+then passed as a **single string** to `exec()`. When `exec` receives a string, Ruby
+invokes the shell (`/bin/sh -c`), which processes metacharacters (`; | & $() ...`).
+If a hostname or username contains shell metacharacters, arbitrary commands could execute.
+
+### Fix
+```ruby
+# BEFORE — passes through shell
+exec(cssh_cmd)
+
+# AFTER — bypasses shell; each token is a separate argv element
+exec(*cssh_args)   # cssh_args is built as an Array
+```
+
+`exec` with multiple arguments (or a single-element array splatted) does **not** invoke
+the shell — arguments are passed directly to the OS as `execvp(3)` entries.
+
+### Rollback
+```bash
+git revert HEAD -- lib/chef/knife/ssh.rb
+```
+
+---
+
+## Regression Evidence
+
+```
+bundle exec rspec spec/unit/
+
+1421 examples, 0 failures, 2 pending
+```
+
+All existing specs updated to assert the new `0600` mode argument, confirming
+the permission change is validated in the test suite.
+
+---
+
+## Update Process for Future Security Reviews
+
+1. **File creation**: Any `File.open(path, "w")` that writes key material, tokens,
+   or PEM content should include mode `0600` as the third argument.
+2. **Shell injection**: Prefer array form of `system()`, `exec()`, and `Open3.popen*`
+   over string interpolation. Use `Shellwords.escape` if string form is unavoidable.
+3. **Secret scanning**: Gitleaks CI job (`.github/workflows/secret-scan.yml`) scans
+   every PR — do not add real credentials to any file tracked by git.
+4. Run `bundle exec rspec spec/unit/` after any security change to catch mock mismatches.

--- a/cspell.json
+++ b/cspell.json
@@ -1659,7 +1659,9 @@
     "customfield",
     "bmbm",
     "stackprof",
-    "rubyprof"
+    "rubyprof",
+    "metacharacter",
+    "metacharacters"
   ],
   // flagWords - list of words to be always considered incorrect
   // This is useful for offensive words and common spelling errors.

--- a/lib/chef/knife/client_create.rb
+++ b/lib/chef/knife/client_create.rb
@@ -94,7 +94,7 @@ class Chef
         # output private_key if one
         if final_client.private_key
           if config[:file]
-            File.open(config[:file], "w") do |f|
+            File.open(config[:file], "w", 0600) do |f|
               f.print(final_client.private_key)
             end
           else

--- a/lib/chef/knife/client_reregister.rb
+++ b/lib/chef/knife/client_reregister.rb
@@ -46,7 +46,7 @@ class Chef
         Chef::Log.trace("Updated client data: #{client.inspect}")
         key = client.private_key
         if config[:file]
-          File.open(config[:file], "w") do |f|
+          File.open(config[:file], "w", 0600) do |f|
             f.print(key)
           end
         else

--- a/lib/chef/knife/configure_client.rb
+++ b/lib/chef/knife/configure_client.rb
@@ -38,7 +38,7 @@ class Chef
           file.puts("validation_client_name '#{Chef::Config[:validation_client_name]}'")
         end
         ui.info("Writing validation.pem")
-        File.open(File.join(@config_dir, "validation.pem"), "w") do |validation|
+        File.open(File.join(@config_dir, "validation.pem"), "w", 0600) do |validation|
           validation.puts(File.read(Chef::Config[:validation_key]))
         end
       end

--- a/lib/chef/knife/key_create.rb
+++ b/lib/chef/knife/key_create.rb
@@ -64,7 +64,7 @@ class Chef
       end
 
       def output_private_key_to_file(private_key)
-        File.open(@config[:file], "w") do |f|
+        File.open(@config[:file], "w", 0600) do |f|
           f.print(private_key)
         end
       end

--- a/lib/chef/knife/key_edit.rb
+++ b/lib/chef/knife/key_edit.rb
@@ -66,7 +66,7 @@ class Chef
       end
 
       def output_private_key_to_file(private_key)
-        File.open(@config[:file], "w") do |f|
+        File.open(@config[:file], "w", 0600) do |f|
           f.print(private_key)
         end
       end

--- a/lib/chef/knife/org_create.rb
+++ b/lib/chef/knife/org_create.rb
@@ -50,7 +50,7 @@ class Chef
         org = Chef::Org.from_hash({ "name" => org_name,
                                     "full_name" => org_full_name }).create
         if config[:filename]
-          File.open(config[:filename], "w") do |f|
+          File.open(config[:filename], "w", 0600) do |f|
             f.print(org.private_key)
           end
         else

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -563,16 +563,21 @@ class Chef
         end
         raise Chef::Exceptions::Exec, "no command found for cssh" unless cssh_cmd
 
+        # Build command as an array to avoid shell metacharacter injection.
+        # exec(array) bypasses the shell entirely; each element is passed verbatim
+        # to the OS as a separate argv entry.
+        cssh_args = [cssh_cmd]
+
         # pass in the consolidated identity file option to cssh(X)
         if config[:ssh_identity_file]
-          cssh_cmd << " --ssh_args '-i #{File.expand_path(config[:ssh_identity_file])}'"
+          cssh_args += ["--ssh_args", "-i #{File.expand_path(config[:ssh_identity_file])}"]
         end
 
         session.servers_for.each do |server|
-          cssh_cmd << " #{server.user ? "#{server.user}@#{server.host}" : server.host}"
+          cssh_args << (server.user ? "#{server.user}@#{server.host}" : server.host)
         end
-        Chef::Log.debug("Starting cssh session with command: #{cssh_cmd}")
-        exec(cssh_cmd)
+        Chef::Log.debug("Starting cssh session with command: #{cssh_args.join(" ")}")
+        exec(*cssh_args)
       end
 
       def get_stripped_unfrozen_value(value)

--- a/lib/chef/knife/user_create.rb
+++ b/lib/chef/knife/user_create.rb
@@ -153,7 +153,7 @@ class Chef
         ui.info("Created #{user.username}")
         if final_user["chef_key"] && final_user["chef_key"]["private_key"]
           if config[:file]
-            File.open(config[:file], "w") do |f|
+            File.open(config[:file], "w", 0600) do |f|
               f.print(final_user["chef_key"]["private_key"])
             end
           else

--- a/lib/chef/knife/user_reregister.rb
+++ b/lib/chef/knife/user_reregister.rb
@@ -47,7 +47,7 @@ class Chef
         Chef::Log.trace("Updated user data: #{user.inspect}")
         key = user.private_key
         if config[:file]
-          File.open(config[:file], "w") do |f|
+          File.open(config[:file], "w", 0600) do |f|
             f.print(key)
           end
         else

--- a/spec/unit/knife/client_create_spec.rb
+++ b/spec/unit/knife/client_create_spec.rb
@@ -138,7 +138,7 @@ describe Chef::Knife::ClientCreate do
         it "should write the private key to a file" do
           filehandle = double("Filehandle")
           expect(filehandle).to receive(:print).with("woot")
-          expect(File).to receive(:open).with(file_path, "w").and_yield(filehandle)
+          expect(File).to receive(:open).with(file_path, "w", 0600).and_yield(filehandle)
           knife.run
         end
 

--- a/spec/unit/knife/client_reregister_spec.rb
+++ b/spec/unit/knife/client_reregister_spec.rb
@@ -53,7 +53,7 @@ describe Chef::Knife::ClientReregister do
 
       @knife.config[:file] = "/tmp/monkeypants"
       filehandle = StringIO.new
-      expect(File).to receive(:open).with("/tmp/monkeypants", "w").and_yield(filehandle)
+      expect(File).to receive(:open).with("/tmp/monkeypants", "w", 0600).and_yield(filehandle)
       @knife.run
       expect(filehandle.string).to eq("foo_key")
     end

--- a/spec/unit/knife/configure_client_spec.rb
+++ b/spec/unit/knife/configure_client_spec.rb
@@ -45,7 +45,7 @@ describe Chef::Knife::ConfigureClient do
         @validation_file = StringIO.new
         expect(File).to receive(:open).with("/home/bob/.chef/client.rb", "w")
           .and_yield(@client_file)
-        expect(File).to receive(:open).with("/home/bob/.chef/validation.pem", "w")
+        expect(File).to receive(:open).with("/home/bob/.chef/validation.pem", "w", 0600)
           .and_yield(@validation_file)
         expect(IO).to receive(:read).and_return("foo_bar_baz")
       end

--- a/spec/unit/knife/user_reregister_spec.rb
+++ b/spec/unit/knife/user_reregister_spec.rb
@@ -49,7 +49,7 @@ describe Chef::Knife::UserReregister do
     expect(user_mock).to receive(:reregister).and_return(user_mock)
     knife.config[:file] = "/tmp/a_file"
     filehandle = StringIO.new
-    expect(File).to receive(:open).with("/tmp/a_file", "w").and_yield(filehandle)
+    expect(File).to receive(:open).with("/tmp/a_file", "w", 0600).and_yield(filehandle)
     knife.run
     expect(filehandle.string).to eq("private_key")
   end


### PR DESCRIPTION
<h2>Summary</h2>
<p>Two targeted security hygiene fixes across <code>lib/chef/knife/</code>, found via manual review, plus updated security documentation.</p>

<h2>Patch Plan</h2>
<ol>
  <li><strong>Fix 1 — Private key/PEM file permissions (8 files)</strong><br>
    All commands that write private keys or PEM material used <code>File.open(path, "w")</code>
    — inherits process umask (typically <code>0644</code> = world-readable).<br>
    Fix: <code>File.open(path, "w", 0600)</code> — owner read/write only, regardless of umask.
  </li>
  <li><strong>Fix 2 — <code>exec(cssh_cmd)</code> shell-string injection (ssh.rb:575)</strong><br>
    <code>cssh_cmd</code> was built from <code>server.user</code>/<code>server.host</code> then passed as a string to <code>exec()</code>.
    String form invokes <code>/bin/sh -c</code>; metacharacters in hostname/user could be interpreted.<br>
    Fix: build as <code>cssh_args</code> array and use <code>exec(*cssh_args)</code> — bypasses shell entirely.
  </li>
</ol>

<h2>Evidence — Findings Table</h2>
<table>
  <tr><th>Finding</th><th>File(s)</th><th>Risk</th><th>Fix</th></tr>
  <tr><td>Private key 0644 → 0600</td><td>key_create, key_edit, org_create, user_create, user_reregister, client_reregister, client_create, configure_client</td><td>World-readable keys on multi-user systems</td><td><code>File.open(path, "w", 0600)</code></td></tr>
  <tr><td>exec() string form</td><td>ssh.rb:575</td><td>Shell metachar injection via hostname/user</td><td>Array form <code>exec(*cssh_args)</code></td></tr>
</table>

<h2>Scripted / Repeatable Approach</h2>
<p>The file permission fix can be reapplied or audited with:</p>
<pre>grep -rn "File.open.*\"w\"" lib/chef/knife/ --include="*.rb" | grep -v "#"
# Any result writing credential content should use "w", 0600</pre>

<h2>Regression</h2>
<pre>bundle exec rspec spec/unit/ → 1421 examples, 0 failures, 2 pending</pre>
<p>4 spec files updated to assert new <code>0600</code> mode arg, validating the change in test suite.</p>

<h2>Files Changed</h2>
<ul>
  <li>8 <code>lib/chef/knife/*.rb</code> files — <code>0600</code> mode on credential writes</li>
  <li><code>lib/chef/knife/ssh.rb</code> — array-form exec</li>
  <li>4 spec files — updated mocks</li>
  <li><code>SECURITY.md</code> — new "Secure File Creation" and "Shell Command Safety" sections</li>
  <li><code>ai-track-docs/security-hygiene.md</code> (new) — findings, rationale, update process</li>
</ul>

<h2>Risk</h2>
<p>Low — permission fix only affects newly created files; exec array form is behavior-equivalent for normal hostnames.</p>

<h2>Rollback</h2>
<pre>git revert HEAD  # restores all 15 files in one step</pre>

<h2>Track</h2>
<p>Level: Run | Exercise: 8 — Security and Secrets</p>

<h2>Delegation Checklist</h2>
<ul>
  <li>✅ Copilot scanned codebase for file permission and shell injection patterns</li>
  <li>✅ Each fix reviewed for side effects before accepting</li>
  <li>✅ Spec mocks updated to assert new security behavior</li>
  <li>✅ Security documentation updated in SECURITY.md and ai-track-docs/</li>
  <li>✅ Scripted audit command documented for future passes</li>
  <li>✅ 1421 examples, 0 failures confirms no regressions</li>
</ul>