### PR TITLE
Remove vendored .github dirs in habitat plans

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -101,6 +101,10 @@ function Invoke-After {
     Remove-Item $pkg_prefix/vendor/cache -Recurse -Force -ErrorAction SilentlyContinue
     Remove-Item $pkg_prefix/vendor/doc -Recurse -Force -ErrorAction SilentlyContinue
 
+    # Remove .github directories from vendored gems to avoid CVE false positives
+    Get-ChildItem $pkg_prefix/vendor/gems -Filter ".github" -Directory -Recurse `
+        | Remove-Item -Recurse -Force
+
     Get-ChildItem $pkg_prefix/vendor/gems -Filter "spec" -Directory -Recurse -Depth 1 |
         Where-Object { $_.FullName -notlike "*knife*" } |
         Remove-Item -Recurse -Force

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -183,8 +183,7 @@ make_pkg_official_distrib() {
 
 do_after() {
   build_line "Removing .github directories from vendored gems..."
-  # Search both gem stores: vendor/gems/ (gem install) and vendor/ruby/$VERSION/gems/ (bundler)
-  find "$pkg_prefix/vendor" -type d -name ".github" \
+  find "$pkg_prefix/vendor/gems" -type d -name ".github" \
     | while read github_dir; do rm -rf "$github_dir"; done
 }
 


### PR DESCRIPTION
## Summary
- remove vendored .github directories during Habitat packaging on Unix plan
- remove vendored .github directories during Habitat packaging on Windows plan
- reduces false positives vulnerabilities from vendored gem metadata folders