### PR TITLE
Fix do_after cleanup path for Appbundler gem layout in Linux Habitat plan

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -183,8 +183,9 @@ make_pkg_official_distrib() {
 
 do_after() {
   build_line "Removing .github directories from vendored gems..."
-  find "$pkg_prefix/vendor/gems" -type d -name ".github" \
-    | while read github_dir; do rm -rf "$github_dir"; done
+  # Search the full vendor tree: bundler places gems under vendor/ruby/$VERSION/gems/
+  # (not vendor/gems/ which was the pre-Appbundler layout)
+  find "$pkg_prefix/vendor" -type d -name ".github" -exec rm -rf {} + 2>/dev/null || true
 }
 
 do_strip() {


### PR DESCRIPTION
<h2>Summary</h2>
<p>Fixes the <code>do_after()</code> cleanup step in <code>habitat/plan.sh</code> so that <code>.github</code> directories shipped inside vendored gem sources are properly removed from the final Habitat package.</p>

<h2>Background</h2>
<p>After the Appbundler migration (#168), Bundler installs gems into <code>vendor/ruby/$VERSION/gems/</code> rather than the old flat <code>vendor/gems/</code> path. The existing <code>do_after()</code> function searched the old path (<code>$pkg_prefix/vendor/gems</code>) which no longer exists, so the cleanup was silently a no-op and gem-shipped workflow files remained in the package.</p>

<h2>Changes Made</h2>
<ul>
  <li>Updated <code>find</code> path in <code>do_after()</code> from <code>$pkg_prefix/vendor/gems</code> to <code>$pkg_prefix/vendor</code> to match the Appbundler-era directory layout</li>
  <li>Switched to <code>-exec rm -rf {} +</code> for safer and more efficient deletion</li>
</ul>

<h2>Files Modified</h2>
<ul>
  <li><code>habitat/plan.sh</code> — corrected cleanup path in <code>do_after()</code></li>
</ul>

<h2>Testing</h2>
<ul>
  <li>Built the Habitat package and confirmed no gem-shipped workflow files are present under <code>$pkg_prefix/vendor</code> in the artifact</li>
  <li>Verified the Windows plan (<code>habitat/plan.ps1</code>) already uses the correct path and was not affected</li>
</ul>