### PR TITLE
Update ohai to 19.1.40

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,12 +384,12 @@ GEM
     netrc (0.11.0)
     nori (2.7.1)
       bigdecimal
-    ohai (19.1.37)
+    ohai (19.1.40)
       base64
       chef-config (>= 14.12, < 20)
       chef-utils (>= 16.0, < 20)
       ffi (>= 1.15.5)
-      ffi-yajl (>= 2.2, < 4.0)
+      ffi-yajl (>= 2.2, < 3.0)
       ipaddress
       mixlib-cli (>= 1.7.0)
       mixlib-config (>= 2.0, < 4.0)

--- a/NOTICE
+++ b/NOTICE
@@ -246,7 +246,7 @@ Components:
 | net-ssh-multi 1.2.1                    | http://rubyforge.org/projects/net-ssh | MIT License                              |
 | nicksieger's multipart-post 2.4.1      | http://github.com/nicksieger/multipar | MIT License                              |
 |                                        |   t-post                              |                                          |
-| opscode-ohai 19.1.37                   | http://github.com/opscode/ohai/tree/m | Apache License 2.0                       |
+| opscode-ohai 19.1.40                   | http://github.com/opscode/ohai/tree/m | Apache License 2.0                       |
 |                                        |   aster                               |                                          |
 | ostruct 0.6.3                          | https://github.com/ruby/ostruct       | BSD 2-clause "Simplified" License        |
 | parser 3.3.11.1                        | http://github.com/whitequark/parser   | MIT License                              |
@@ -351,7 +351,7 @@ License Data and Text:
 -------------------------------------------------------------------------------------------------------------------------
 
 Apache License 2.0
-(Addressable URI parser 2.9.0, AWS SDK for Ruby 1.12.1, AWS SDK for Ruby 1.123.0, AWS SDK for Ruby 1.1235.0, AWS SDK for Ruby 1.218.0, AWS SDK for Ruby 1.4.0, AWS SDK for Ruby 1.624.0, aws-sdk-core-ruby 3.252.0, Chef 19.3.15, chef-licensing 1.4.1, chef-vault 4.2.12, chef-winrm 2.5.0, chef-winrm-elevated 1.2.5, chef-winrm-fs 1.4.2, chef-zero 15.1.0, cookstyle 8.6.10, faraday-http-cache 2.6.1, ffi-libarchive 1.1.14, gcewinpass 1.1.0, google-api-ruby-client 0.18.0, google-api-ruby-client 0.53.0, google-cloud-core 2.3.1, google-logging-utils 0.2.0, googleauth 1.17.1, jmespath rubygems 1.6.2, knife 19.0.105, knife-cloud 4.0.15, libyajl2 2.1.0, license-acceptance 2.1.13, mixlib-archive 1.3.3, mixlib-shellout 3.4.10, opscode-ohai 19.1.37, semverse 3.0.2, sporkmonger's uuidtools 2.2.0, train-core 3.16.5, train-winrm 0.4.3, wmi-lite 1.0.7)
+(Addressable URI parser 2.9.0, AWS SDK for Ruby 1.12.1, AWS SDK for Ruby 1.123.0, AWS SDK for Ruby 1.1235.0, AWS SDK for Ruby 1.218.0, AWS SDK for Ruby 1.4.0, AWS SDK for Ruby 1.624.0, aws-sdk-core-ruby 3.252.0, Chef 19.3.15, chef-licensing 1.4.1, chef-vault 4.2.12, chef-winrm 2.5.0, chef-winrm-elevated 1.2.5, chef-winrm-fs 1.4.2, chef-zero 15.1.0, cookstyle 8.6.10, faraday-http-cache 2.6.1, ffi-libarchive 1.1.14, gcewinpass 1.1.0, google-api-ruby-client 0.18.0, google-api-ruby-client 0.53.0, google-cloud-core 2.3.1, google-logging-utils 0.2.0, googleauth 1.17.1, jmespath rubygems 1.6.2, knife 19.0.105, knife-cloud 4.0.15, libyajl2 2.1.0, license-acceptance 2.1.13, mixlib-archive 1.3.3, mixlib-shellout 3.4.10, opscode-ohai 19.1.40, semverse 3.0.2, sporkmonger's uuidtools 2.2.0, train-core 3.16.5, train-winrm 0.4.3, wmi-lite 1.0.7)
 
 Apache License
 Version 2.0, January 2004


### PR DESCRIPTION
<h2>Summary</h2>
<p>Updates ohai gem from 19.1.37 to 19.1.40</p>

<h2>Changes Made</h2>
<ul>
  <li>Bump ohai from 19.1.37 to 19.1.40</li>
  <li>Update ohai's ffi-yajl requirement from &lt; 4.0 to &lt; 3.0 (per upstream change)</li>
</ul>

<h2>No Additional Dependencies Required</h2>
<p>All existing dependencies satisfy ohai 19.1.40 requirements.</p>