### PR TITLE
Fix windows_bootstrap_context_spec flakiness on windows-2025 CI

### DIFF
--- a/spec/unit/knife/core/windows_bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/windows_bootstrap_context_spec.rb
@@ -23,6 +23,14 @@ describe Chef::Knife::Core::WindowsBootstrapContext do
   let(:chef_config) { Chef::Config.save } # "dup" to a hash
   let(:bootstrap_context) { Chef::Knife::Core::WindowsBootstrapContext.new(config, nil, chef_config, nil) }
 
+  before do
+    # Stub path methods to return consistent values across all platforms.
+    # On actual Windows (e.g. windows-2025 CI), these methods may resolve
+    # to a different drive letter based on the gem installation path.
+    allow(ChefConfig::Config).to receive(:etc_chef_dir).with(windows: true).and_return("C:\\chef")
+    allow(ChefConfig::Config).to receive(:c_opscode_dir).and_return("C:\\opscode\\chef")
+  end
+
   describe "fips" do
     context "when fips is set" do
       before do


### PR DESCRIPTION
<h2>Summary</h2>
<p>Fixes intermittent unit test failures in <code>windows_bootstrap_context_spec.rb</code> on the <code>windows-2025</code> GitHub Actions runner.</p>

<h2>Problem</h2>
<p>The following tests fail on <code>windows-2025</code> but pass on all other platforms (ubuntu, macos, windows-2022):</p>
<ul>
  <li><code>spec/unit/knife/core/windows_bootstrap_context_spec.rb:164</code> - config_content generates the config file data</li>
  <li><code>spec/unit/knife/core/windows_bootstrap_context_spec.rb:192</code> - start_chef returns expected string with default values</li>
  <li><code>spec/unit/knife/core/windows_bootstrap_context_spec.rb:201</code> - start_chef returns expected string with license_id</li>
  <li><code>spec/unit/knife/core/windows_bootstrap_context_spec.rb:212</code> - start_chef exclude license key when disable_license_activation is true</li>
  <li><code>spec/unit/knife/core/windows_bootstrap_context_spec.rb:232</code> - start_chef with bootstrap_url and chef-ice</li>
</ul>

<h2>Root Cause</h2>
<p>The tests hardcode expected paths like <code>C:\chef</code> and <code>C:\opscode\chef</code>, but the source code resolves these dynamically via <code>ChefConfig::Config.etc_chef_dir(windows: true)</code> and <code>ChefConfig::Config.c_opscode_dir</code>.</p>
<p>These class methods use <code>windows_installation_drive</code> which detects the drive letter at runtime from the gem installation path (<code>File.expand_path(__FILE__).split("/", 2)[0]</code>). The memoized result is stored as a class-level instance variable (<code>@etc_chef_dir</code>) that is <strong>NOT</strong> cleared by <code>Chef::Config.reset</code> between tests.</p>
<p>When the <code>windows-2025</code> runner image was updated by GitHub (they deploy <a href="https://github.com/actions/runner-images#image-releases">weekly updates</a> to runner images), the system configuration changed in a way that affected path resolution, causing these tests to fail.</p>

<h2>Evidence</h2>
<ul>
  <li>Tests <strong>passed</strong> on <code>windows-2025</code> in <a href="https://github.com/chef/knife/pull/186">PR #186</a> (run ~July 1, 2026)</li>
  <li>Tests <strong>failed</strong> on <code>windows-2025</code> in <a href="https://github.com/chef/knife/pull/187">PR #187</a> (run ~July 10, 2026)</li>
  <li>Neither PR modifies any test code or source code — both are dependabot bumps</li>
  <li>The <code>windows-2022</code> runner is unaffected in both cases</li>
  <li>A runner image update occurred in the interval between the two runs</li>
</ul>

<h2>Fix</h2>
<p>Stub <code>ChefConfig::Config.etc_chef_dir(windows: true)</code> and <code>ChefConfig::Config.c_opscode_dir</code> in a top-level <code>before</code> block to return deterministic values (<code>C:\chef</code> and <code>C:\opscode\chef</code>). This ensures the tests validate the <em>logic</em> of config generation and path construction, not the platform-specific drive letter detection.</p>

<h2>References</h2>
<ul>
  <li><a href="https://github.com/chef/knife/pull/187">PR #187</a> — where the failures are observed</li>
  <li><a href="https://github.com/actions/runner-images">actions/runner-images</a> — GitHub deploys weekly updates to runner images</li>
  <li><a href="https://github.com/actions/runner-images#image-releases">Image Releases documentation</a> — confirms weekly cadence</li>
</ul>