### PR TITLE
CHEF-37332: add Linux ARM Habitat validation in Expeditor pipeline

### DIFF
--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -27,7 +27,7 @@ steps:
       queue: default-privileged-aarch64
     plugins:
       - docker#v3.5.0:
-          image: ruby:3.4
+          image: ruby:3.4.2-bullseye
           privileged: true
           propagate-environment: true
           environment:

--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -20,6 +20,20 @@ steps:
           environment:
             - HAB_AUTH_TOKEN
 
+  - label: ":linux: Arm64 Validate Habitat Builds of Knife"
+    commands:
+      - .expeditor/buildkite/artifact.habitat.test.sh
+    agents:
+      queue: default-privileged-aarch64
+    plugins:
+      - docker#v3.5.0:
+          image: ruby:3.4
+          privileged: true
+          propagate-environment: true
+          environment:
+            - HAB_AUTH_TOKEN
+            - BUILD_PKG_TARGET: "aarch64-linux"
+
   - label: ":windows: Validate Habitat Builds of Knife"
     commands:
       - .expeditor/buildkite/artifact.habitat.test.ps1

--- a/habitat/aarch64-linux/plan.sh
+++ b/habitat/aarch64-linux/plan.sh
@@ -1,0 +1,2 @@
+source "$(dirname "${BASH_SOURCE[0]}")/../plan.sh"
+# Reuse the default Linux plan for Linux ARM (aarch64) builds.

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -31,7 +31,7 @@ pkg_build_deps=(
 )
 
 pkg_version() {
-  cat "../VERSION"
+  cat "$SRC_PATH/VERSION"
 }
 
 do_before() {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -39,6 +39,7 @@ pkg_version() {
 # the Linux ARM target), so source unpacking and file lookups below always
 # reference the correct location instead of assuming a fixed "..' depth.
 _repo_root() {
+  git config --global --add safe.directory '*' 2>/dev/null || true
   git -C "$PLAN_CONTEXT" rev-parse --show-toplevel
 }
 

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -34,6 +34,14 @@ pkg_version() {
   cat "$SRC_PATH/VERSION"
 }
 
+# Resolve the repository root regardless of which directory this plan is
+# invoked from (habitat/ for the default target, habitat/aarch64-linux/ for
+# the Linux ARM target), so source unpacking and file lookups below always
+# reference the correct location instead of assuming a fixed "..' depth.
+_repo_root() {
+  git -C "$PLAN_CONTEXT" rev-parse --show-toplevel
+}
+
 do_before() {
   update_pkg_version
 }
@@ -62,7 +70,7 @@ do_prepare() {
 # Unpack the source code into the Habitat cache path
 do_unpack() {
   mkdir -pv "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  cp -RT "$PLAN_CONTEXT"/.. "$HAB_CACHE_SRC_PATH/$pkg_dirname/"
+  cp -RT "$(_repo_root)" "$HAB_CACHE_SRC_PATH/$pkg_dirname/"
 }
 
 # Build the Knife gem from its specification file
@@ -93,11 +101,11 @@ do_build() {
 do_install() {
 
   # Copy NOTICE to the package directory
-  if [[ -f "$PLAN_CONTEXT/../NOTICE" ]]; then
+  if [[ -f "$(_repo_root)/NOTICE" ]]; then
     build_line "Copying NOTICE to package directory"
-    cp "$PLAN_CONTEXT/../NOTICE" "$pkg_prefix/"
+    cp "$(_repo_root)/NOTICE" "$pkg_prefix/"
   else
-    build_line "Warning: NOTICE not found at $PLAN_CONTEXT/../NOTICE"
+    build_line "Warning: NOTICE not found at $(_repo_root)/NOTICE"
   fi
 
   export GEM_HOME="$pkg_prefix/vendor"
@@ -132,7 +140,7 @@ do_install() {
 
   build_line "** patching binstubs to allow running directly"
   for binstub in ${pkg_prefix}/bin/*; do
-    sed -i "/require \"rubygems\"/r ${PLAN_CONTEXT}/../binstub_patch.rb" "$binstub"
+    sed -i "/require \"rubygems\"/r $(_repo_root)/binstub_patch.rb" "$binstub"
   done
 
   build_line "** creating wrapper for runtime environment"


### PR DESCRIPTION
## Summary
Adds Linux ARM64 (aarch64) Habitat build validation to the Knife Expeditor/Buildkite pipeline, and fixes the Habitat plan to build correctly when invoked from the new ARM target directory.

## What Changed
- Added a new `":linux: Arm64 Validate Habitat Builds of Knife"` step to `.expeditor/habitat-test.pipeline.yml`
  - Runs on Buildkite queue `default-privileged-aarch64`
  - Uses the `docker#v3.5.0` plugin with image `ruby:3.4.2-bullseye`, `privileged: true`, `propagate-environment: true`
  - Sets `BUILD_PKG_TARGET: "aarch64-linux"`
  - Keeps `HAB_AUTH_TOKEN` propagated via the environment, consistent with the existing Linux/Windows steps
- Introduced `habitat/aarch64-linux/plan.sh`, sourcing the existing `habitat/plan.sh` to reuse the default Linux build logic for aarch64 (ARM) targets
- Fixed `habitat/plan.sh` so the build works correctly regardless of which directory depth the plan is invoked from (`habitat/` for the default target vs. `habitat/aarch64-linux/` for the new ARM target):
  - `pkg_version()` now reads `$SRC_PATH/VERSION` instead of the relative `../VERSION`, which resolved to the wrong file when invoked from the ARM plan
  - Added a `_repo_root()` helper that resolves the repository root via `git rev-parse --show-toplevel`
  - `do_unpack()` now copies the full repository root (via `_repo_root()`) into the Habitat build cache, instead of a fixed `$PLAN_CONTEXT/..`, which previously copied too shallow a tree and caused the build to fail with `Could not locate Gemfile`
  - The `NOTICE` copy and `binstub_patch.rb` injection in `do_install()` also use `_repo_root()` for the same reason
  - `_repo_root()` marks all directories as git-safe first, since the Habitat build sandbox mounts the source tree with different ownership, which otherwise causes git to fail with a "dubious ownership" error

## Result
Habitat package builds for Knife are now validated on Linux ARM64 via Buildkite/Expeditor, in addition to the existing Linux (x86_64) and Windows validation steps, and the Habitat plan builds successfully on both the default and ARM targets.

## Jira
CHEF-37332
