### PR TITLE
Improve knife --help with topic-based command groups

### DIFF
--- a/lib/chef/application/knife.rb
+++ b/lib/chef/application/knife.rb
@@ -235,7 +235,7 @@ class Chef::Application::Knife < Chef::Application
 
     if want_help?
       help_result = Chef::Knife.show_help(topic)
-      exitcode = 1 if help_result == :unknown_topic && exitcode.zero?
+      exitcode = 1 if help_result == :unknown_topic && exitcode == 0
     else
       Chef::Knife.list_commands
     end

--- a/lib/chef/application/knife.rb
+++ b/lib/chef/application/knife.rb
@@ -212,8 +212,10 @@ class Chef::Application::Knife < Chef::Application
   def print_help_and_exit(exitcode = 1, fatal_message = nil)
     Chef::Log.error(fatal_message) if fatal_message
 
+    topic = help_topic
+
     begin
-      parse_options
+      parse_options if topic.nil?
     rescue OptionParser::InvalidOption => e
       puts "#{e}\n"
     end
@@ -226,10 +228,29 @@ class Chef::Application::Knife < Chef::Application
       puts
     end
 
-    puts opt_parser
-    puts
-    Chef::Knife.list_commands
+    if topic.nil? || topic == "all"
+      puts opt_parser
+      puts
+    end
+
+    if want_help?
+      help_result = Chef::Knife.show_help(topic)
+      exitcode = 1 if help_result == :unknown_topic && exitcode.zero?
+    else
+      Chef::Knife.list_commands
+    end
+
     exit exitcode
+  end
+
+  def help_topic
+    return nil unless want_help?
+
+    raw_topic = ARGV[1]
+    return nil if raw_topic.nil? || raw_topic.empty?
+    return nil if raw_topic.start_with?("--")
+
+    Chef::Knife.normalize_help_topic(raw_topic)
   end
 
 end

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -272,7 +272,7 @@ class Chef
       "all" => "full command list",
       "infra" => "node, role, environment, tag",
       "content" => "cookbook, data bag, recipe, supermarket, yaml",
-      "security" => "acl, group, user, client, vault, ssl",
+      "security" => "org, acl, group, user, client, vault, ssl",
       "remote" => "bootstrap, ssh, winrm, wsman, windows",
       "cloud" => "ec2, google",
       "repo" => "path-based, raw, serve",
@@ -284,7 +284,7 @@ class Chef
     HELP_TOPIC_CATEGORIES = {
       "infra" => %w{node role environment tag},
       "content" => ["cookbook", "data bag", "recipe", "supermarket", "yaml"],
-      "security" => ["chef organization management", "acl", "group", "user", "client", "vault", "ssl"],
+      "security" => ["CHEF ORGANIZATION MANAGEMENT", "acl", "group", "user", "client", "vault", "ssl"],
       "remote" => %w{bootstrap ssh winrm wsman windows},
       "cloud" => %w{ec2 google},
       "repo" => %w{path-based raw serve},

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -283,8 +283,8 @@ class Chef
 
     HELP_TOPIC_CATEGORIES = {
       "infra" => %w{node role environment tag},
-      "content" => %w{cookbook data\ bag recipe supermarket yaml},
-      "security" => %w{chef\ organization\ management acl group user client vault ssl},
+      "content" => ["cookbook", "data bag", "recipe", "supermarket", "yaml"],
+      "security" => ["chef organization management", "acl", "group", "user", "client", "vault", "ssl"],
       "remote" => %w{bootstrap ssh winrm wsman windows},
       "cloud" => %w{ec2 google},
       "repo" => %w{path-based raw serve},

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -266,11 +266,42 @@ class Chef
 
     OFFICIAL_PLUGINS = %w{lpar openstack push rackspace vcenter}.freeze
 
+    HELP_TOPIC_ORDER = %w{all infra content security remote cloud repo ops plugins search}.freeze
+
+    HELP_TOPIC_HINTS = {
+      "all" => "full command list",
+      "infra" => "node, role, environment, tag",
+      "content" => "cookbook, data bag, recipe, supermarket, yaml",
+      "security" => "acl, group, user, client, vault, ssl",
+      "remote" => "bootstrap, ssh, winrm, wsman, windows",
+      "cloud" => "ec2, google",
+      "repo" => "path-based, raw, serve",
+      "ops" => "config, configure, rehash, license, exec, status",
+      "plugins" => "installed plugin command families",
+      "search" => "search",
+    }.freeze
+
+    HELP_TOPIC_CATEGORIES = {
+      "infra" => %w{node role environment tag},
+      "content" => %w{cookbook data\ bag recipe supermarket yaml},
+      "security" => %w{chef\ organization\ management acl group user client vault ssl},
+      "remote" => %w{bootstrap ssh winrm wsman windows},
+      "cloud" => %w{ec2 google},
+      "repo" => %w{path-based raw serve},
+      "ops" => %w{config configure rehash license exec status knife},
+      "search" => %w{search},
+    }.freeze
+
+    CORE_HELP_CATEGORIES = HELP_TOPIC_CATEGORIES.values.flatten.uniq.freeze
+
     class << self
-      def list_commands(preferred_category = nil)
-        category_desc = preferred_category ? preferred_category + " " : ""
+      def list_commands(preferred_category = nil, categories: nil, category_desc: nil)
+        category_desc ||= preferred_category ? preferred_category + " " : ""
         msg "Available #{category_desc}subcommands: (for details, knife SUB-COMMAND --help)\n\n"
-        subcommand_loader.list_commands(preferred_category).sort.each do |category, commands|
+        command_groups = subcommand_loader.list_commands(preferred_category)
+        command_groups = command_groups.select { |category, _| categories.include?(category) } if categories
+
+        command_groups.sort.each do |category, commands|
           next if /deprecated/i.match?(category)
 
           msg "** #{category.upcase} COMMANDS **"
@@ -280,6 +311,67 @@ class Chef
           end
           msg
         end
+      end
+
+      def normalize_help_topic(raw_topic)
+        return nil if raw_topic.nil?
+
+        topic = raw_topic.to_s.strip
+        return nil if topic.empty?
+
+        topic = topic[1..] if topic.start_with?("-")
+        topic = topic.downcase
+        topic = "plugins" if topic == "plugin"
+        topic
+      end
+
+      def show_help(topic = nil)
+        return show_help_topics if topic.nil?
+
+        normalized_topic = normalize_help_topic(topic)
+        return show_unknown_help_topic(topic) if normalized_topic.nil?
+
+        return list_commands if normalized_topic == "all"
+
+        if normalized_topic == "plugins"
+          show_plugin_help
+          return show_help_topics
+        end
+
+        categories = HELP_TOPIC_CATEGORIES[normalized_topic]
+        return show_unknown_help_topic(topic) unless categories
+
+        list_commands(nil, categories: categories, category_desc: normalized_topic + " ")
+        show_help_topics
+      end
+
+      def show_help_topics
+        msg "For help on specific knife commands, see the command groups below."
+        HELP_TOPIC_ORDER.each do |topic|
+          msg format("  knife --help -%-8s (%s)", topic, HELP_TOPIC_HINTS[topic])
+        end
+        msg
+        :ok
+      end
+
+      def show_plugin_help
+        all_categories = subcommand_loader.list_commands.keys
+        plugin_categories = all_categories - CORE_HELP_CATEGORIES
+        plugin_categories.reject! { |category| /deprecated/i.match?(category) }
+
+        if plugin_categories.empty?
+          msg "No plugin command groups detected in this environment."
+          return :ok
+        end
+
+        list_commands(nil, categories: plugin_categories, category_desc: "plugins ")
+      end
+
+      def show_unknown_help_topic(topic)
+        msg "Unknown help topic: #{topic}"
+        msg "Valid topics: #{HELP_TOPIC_ORDER.join(", ")}"
+        msg "Use: knife --help -all"
+        :unknown_topic
       end
 
       private

--- a/spec/unit/application/knife_spec.rb
+++ b/spec/unit/application/knife_spec.rb
@@ -44,7 +44,39 @@ describe Chef::Application::Knife do
     @knife = Chef::Application::Knife.new
     allow(@knife).to receive(:puts)
     allow(@knife).to receive(:trap)
+    allow(Chef::Knife).to receive(:show_help).and_return(:ok)
+    allow(Chef::Knife).to receive(:normalize_help_topic).and_call_original
     allow(Chef::Knife).to receive(:list_commands)
+  end
+
+  it "shows short help topics for --help" do
+    with_argv("--help") do
+      expect(@knife).to receive(:puts).with(@knife.opt_parser)
+      expect(Chef::Knife).to receive(:show_help).with(nil).and_return(:ok)
+      expect { @knife.run }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+  end
+
+  it "routes --help -all to the full help topic" do
+    with_argv("--help", "-all") do
+      expect(Chef::Knife).to receive(:show_help).with("all").and_return(:ok)
+      expect { @knife.run }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+  end
+
+  it "routes --help TOPIC to topic help" do
+    with_argv("--help", "cloud") do
+      expect(@knife).not_to receive(:puts).with(@knife.opt_parser)
+      expect(Chef::Knife).to receive(:show_help).with("cloud").and_return(:ok)
+      expect { @knife.run }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+  end
+
+  it "exits non-zero for unknown help topics" do
+    with_argv("--help", "-unknown-topic") do
+      expect(Chef::Knife).to receive(:show_help).with("unknown-topic").and_return(:unknown_topic)
+      expect { @knife.run }.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+    end
   end
 
   it "should exit 1 and print the options if no arguments are given at all" do


### PR DESCRIPTION
**Summary**
This PR improves the Knife help command experience by adding topic-based help navigation (access to the full command catalog is preserved under an '-all' flag.
The current default help output is long and difficult to scan quickly. The presence of plugin commands and other commands linked to very specific use-cases overwhelm the terminal and force users to scroll to reach the commands that they need help with. This change makes it easier for users to discover relevant commands fast, then drill into a focused command group when needed.

**Changes**

- Added a topic-based help index in default `--help`
- Added focused help by topic
- Kept full help available through `--help -all`
- Added clear topic guidance text at the bottom of topic outputs
- Added unknown-topic handling with a valid topics list
- Supported topics: all, infra, content, security, remote, cloud, repo, ops, plugins, search

**Output**
Below is the output for `knife --help`
```Docs: https://docs.chef.io/workstation/knife/
Patents: https://www.chef.io/patents

Usage: knife sub-command (options)
    -s, --server-url URL             Chef Infra Server URL.
        --chef-zero-host HOST        Host to start Chef Infra Zero on.
        --chef-zero-port PORT        Port (or port range) to start Chef Infra Zero on. Port ranges like 1000,1010 or 8889-9999 will try all given ports until one works.
    -k, --key KEY                    Chef Infra Server API client key.
        --[no-]color                 Use colored output, defaults to enabled.
    -c, --config CONFIG              The configuration file to use.
        --config-option OPTION=VALUE Override a single configuration option.
        --defaults                   Accept default values for all questions.
    -d, --disable-editing            Do not open EDITOR, just accept the data as is.
    -e, --editor EDITOR              Set the editor to use for interactive commands.
    -E, --environment ENVIRONMENT    Set the Chef Infra Client environment (except for in searches, where this will be flagrantly ignored).
        --[no-]fips                  Enable FIPS mode.
    -F, --format FORMAT              Which format to use for output. (valid options: 'summary', 'text', 'json', 'yaml', or 'pp')
        --[no-]listen                Whether a local mode (-z) server binds to a port.
    -z, --local-mode                 Point knife commands at local repository instead of Chef Infra Server.
    -u, --user USER                  Chef Infra Server API client username.
        --print-after                Show the data after a destructive operation.
        --profile PROFILE            The credentials profile to select.
    -V, --verbose                    More verbose output. Use twice (-VV) for additional verbosity and three times (-VVV) for maximum verbosity.
    -v, --version                    Show knife version.
    -y, --yes                        Say yes to all prompts for confirmation.
    -h, --help                       Show this help message.

For help on specific knife commands, see the command groups below.
  knife --help -all      (full command list)
  knife --help -infra    (node, role, environment, tag)
  knife --help -content  (cookbook, data bag, recipe, supermarket, yaml)
  knife --help -security (acl, group, user, client, vault, ssl)
  knife --help -remote   (bootstrap, ssh, winrm, wsman, windows)
  knife --help -cloud    (ec2, google)
  knife --help -repo     (path-based, raw, serve)
  knife --help -ops      (config, configure, rehash, license, exec, status)
  knife --help -plugins  (installed plugin command families)
  knife --help -search   (search)
```
  
  Below is the output for `knife --help -infra` for example:
  ```Docs: https://docs.chef.io/workstation/knife/
Patents: https://www.chef.io/patents

Available infra subcommands: (for details, knife SUB-COMMAND --help)

** ENVIRONMENT COMMANDS **
knife environment compare [ENVIRONMENT..] (options)
knife environment create ENVIRONMENT (options)
knife environment delete ENVIRONMENT (options)
knife environment edit ENVIRONMENT (options)
knife environment from file FILE [FILE..] (options)
knife environment list (options)
knife environment show ENVIRONMENT (options)

** NODE COMMANDS **
knife node bulk delete REGEX (options)
knife node create NODE (options)
knife node delete [NODE [NODE]] (options)
knife node edit NODE (options)
knife node environment set NODE ENVIRONMENT
knife node from file FILE (options)
knife node list (options)
knife node policy set NODE POLICY_GROUP POLICY_NAME (options)
knife node run_list add [NODE] [ENTRY [ENTRY]] (options)
knife node run_list remove [NODE] [ENTRY [ENTRY]] (options)
knife node run_list set NODE ENTRIES (options)
knife node show NODE (options)

** ROLE COMMANDS **
knife role bulk delete REGEX (options)
knife role create ROLE (options)
knife role delete ROLE (options)
knife role edit ROLE (options)
knife role env_run_list add [ROLE] [ENVIRONMENT] [ENTRY [ENTRY]] (options)
knife role env_run_list clear [ROLE] [ENVIRONMENT] (options)
knife role env_run_list remove [ROLE] [ENVIRONMENT] [ENTRIES] (options)
knife role env_run_list replace [ROLE] [ENVIRONMENT] [OLD_ENTRY] [NEW_ENTRY] (options)
knife role env_run_list set [ROLE] [ENVIRONMENT] [ENTRIES] (options)
knife role from file FILE [FILE..] (options)
knife role list (options)
knife role run_list add [ROLE] [ENTRY [ENTRY]] (options)
knife role run_list clear [ROLE] (options)
knife role run_list remove [ROLE] [ENTRY] (options)
knife role run_list replace [ROLE] [OLD_ENTRY] [NEW_ENTRY] (options)
knife role run_list set [ROLE] [ENTRIES] (options)
knife role show ROLE (options)

** TAG COMMANDS **
knife tag create NODE TAG ...
knife tag delete NODE TAG ...
knife tag list NODE

For help on specific knife commands, see the command groups below.
  knife --help -all      (full command list)
  knife --help -infra    (node, role, environment, tag)
  knife --help -content  (cookbook, data bag, recipe, supermarket, yaml)
  knife --help -security (acl, group, user, client, vault, ssl)
  knife --help -remote   (bootstrap, ssh, winrm, wsman, windows)
  knife --help -cloud    (ec2, google)
  knife --help -repo     (path-based, raw, serve)
  knife --help -ops      (config, configure, rehash, license, exec, status)
  knife --help -plugins  (installed plugin command families)
  knife --help -search   (search)
```